### PR TITLE
Support running uncompiled CoffeeScript apps

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -189,7 +189,7 @@ function unixRelative(from, to) {
 function parseName(parentFilename, options) {
   var parentDir = dirname(parentFilename)
     , root = parentDir
-    , base = basename(parentFilename, '.js');
+    , base = basename(parentFilename).replace(/\.(?:js|coffee)$/, '');
   if (base === 'index') {
     base = basename(parentDir);
     root = dirname(dirname(parentDir));


### PR DESCRIPTION
I wanted to run my application without compiling it first. There were some necessary modifications to the coffee app generated by the Derby commandline. Beyond that a small fix in `parseName` was the only thing I needed to reach the goal.

If you find it useful, I can contribute the modifications required to generate a compilation free coffee app too.
