### PR TITLE
fix: using shimmed doc.contains

### DIFF
--- a/lib/Dom.js
+++ b/lib/Dom.js
@@ -351,7 +351,7 @@ function getRange(name) {
 
   // Comment nodes may continue to exist even if they have been removed from
   // the page. Thus, make sure they are still somewhere in the page body
-  if (!doc.body.contains(start)) {
+  if (!doc.contains(start)) {
     delete markers[name];
     delete markers['$' + name];
     return;


### PR DESCRIPTION
Fixes safari on Mac/iOS
Closes https://github.com/codeparty/derby/issues/79
