### PR TITLE
Require 'up' only when not in a production env

### DIFF
--- a/lib/derby.server.js
+++ b/lib/derby.server.js
@@ -4,7 +4,6 @@ var fs = require('fs')
   , EventEmitter = require('events').EventEmitter
   , racer = require('racer')
   , tracks = require('tracks')
-  , up = require('up')
   , View = require('./View.server')
   , autoRefresh = require('./refresh.server').autoRefresh
   , util = racer.util
@@ -46,6 +45,7 @@ proto = {
       throw new Error('`' + file + '` does not export a valid `http.Server`');
     }
     if (!isProduction) {
+      var up = require('up');
       // TODO: This extends the internal API of Up. It would be better
       // if Up supported workers being able to force a global reload
       onMessage = up.Worker.prototype.onMessage;


### PR DESCRIPTION
Not sure if this is frowned upon in node land (I'm quite new around here), but this should help somewhat with memory I think, and it actually lets me deploy to nodejitsu without problems (there's a limitation on using os.cpus() on their platform).
