### PR TITLE
`derby new` - Cannot find module './lib/derby'

### DIFF
--- a/bin/derby
+++ b/bin/derby
@@ -1,2 +1,3 @@
 #!/usr/bin/env node
-require('./lib/derby');
+require('coffee-script');
+require('./src/derby');

--- a/package.json
+++ b/package.json
@@ -22,13 +22,11 @@
     "nib": ">=0.4.1",
     "commander": ">=0.5.2",
     "mkdirp": ">=0.3.3",
-    "up": ">=0.1.4"
+    "up": ">=0.1.4",
+    "coffee-script": ">=1.3.1"
   },
   "engines": {
     "node": ">=0.6.0"
-  },
-  "devDependencies": {
-    "coffee-script": ">=1.3.1"
   },
   "optionalDependencies": {}
 }


### PR DESCRIPTION
see also #171. Seems there was a missing `make compile` step in recent commits. No need, just require coffee-script
