### PR TITLE
Added 'or' + 'and' functions to view

### DIFF
--- a/lib/View.js
+++ b/lib/View.js
@@ -50,7 +50,7 @@ var defaultGetFns = {
     return !!(a || b);
   }
 , and: function(a, b) {
-    return a && b;
+    return !!(a && b);
   }
 , join: function(items, property, separator) {
     var list, i;


### PR DESCRIPTION
This adds two functions to views.
- or
- and

Both could be rewritten using the boolean operator as:

```
return Boolean (a || b)
```

However, I prefer the double bang. I didn't see anywhere in the mocha specs that directly test the functionality of the `equal` function, but if you'd like me to add specific tests please let me know.

Perhaps in the future these could be extended to allow an unlimited number of parameters.
