### PR TITLE
Fixes to model.at for each blocks

### DIFF
--- a/lib/derby.Model.js
+++ b/lib/derby.Model.js
@@ -40,7 +40,8 @@ Model.prototype.at = function(node, absolute) {
           }
         }
         if (blockPath.type === 'if' || blockPath.type === 'unless' ||
-            blockPath.type === 'else if' || blockPath.type === 'else')
+            blockPath.type === 'else if' || blockPath.type === 'else' ||
+            blockPath.type === 'with')
           continue;
         return this.__at(path, true);
       }
@@ -61,7 +62,8 @@ Model.prototype.at = function(node, absolute) {
         }
       }
       if (blockPath.type !== 'if' && blockPath.type !== 'unless' &&
-	      blockPath.type !== 'else if' && blockPath.type !== 'else')
+          blockPath.type !== 'else if' && blockPath.type !== 'else' &&
+          blockPath.type !== 'with')
         return this.__at(path, true);
     }
     last = node;


### PR DESCRIPTION
Fixes #158 
- Added skip text nodes by @reneclaus inside each blocks.
- Checks if path is not a block conditional path.
- No returns conditional block paths unless $derbyMarkerId is reach.
