### PR TITLE
Adding a pre-defined template that persists elements across page changes

### DIFF
--- a/lib/View.js
+++ b/lib/View.js
@@ -361,6 +361,13 @@ function render(model, ns, ctx, renderHash) {
         this.get('footer', ns, ctx)
     , doc = window.document
     , err
+    , fixtureEl = doc.getElementById('_$fixture') || (function(html) {
+          var e = doc.createElement('div')
+          e.id = '_$fixture';
+          e.innerHTML = html;
+          doc.getElementsByTagName('body')[0].appendChild(e);
+          return e;
+        })(this.get('fixture', ns, ctx));
 
   if (!model.flags.isProduction && renderHash) {
     // Check hashes in development to help find rendering bugs
@@ -399,6 +406,7 @@ function render(model, ns, ctx, renderHash) {
   fakeRoot = doc.createElement('html');
   fakeRoot.innerHTML = bodyHtml;
   body = fakeRoot.getElementsByTagName('body')[0];
+  body.appendChild(fixtureEl);
   documentElement.replaceChild(body, doc.body);
   doc.title = title;
 


### PR DESCRIPTION
This change modifies the client side View.js render method to take into account a pre-defined <Fixture:> template which can be used to persist DOM elements across page changes.

My use case is a canvas app in which I want to initialize the canvas only once and then hang on to the original canvas element across page changes. I don't see any sane way to do this currently, as render() blows out the entire body and re-renders it every time.

The solution is kind of hacky, but it's simple.

If anyone has better ideas on how to accomplish this, I'm open to ideas. This probably needs some docs/tests but I'm not really sure that this isn't completely stupid.
