### PR TITLE
allow users to import standard css files (eg, from public/vendor)

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -71,6 +71,7 @@ function stylusCompiler(root, clientName, compress, callback) {
         .use(nib())
         .set('filename', path)
         .set('compress', compress)
+        .set('include css', true)
         .render(callback);
     });
   });


### PR DESCRIPTION
use `.set('include css', true)` to allow devs to import standard (non-stylus) css files. Preferably there'd be some custom `.set`s we can perform on stylus, the same way we can on racer
