### PR TITLE
Add support for view functions in static views

### DIFF
--- a/lib/derby.server.js
+++ b/lib/derby.server.js
@@ -92,14 +92,33 @@ function createStatic(root) {
 function Static(root, libraries) {
   this.root = root;
   this.libraries = libraries;
-  this.views = {};
+
+  // Allow clients to define view functions
+  this.view = {
+    _instances:{},
+    fnDefs: {},
+    fn: function (name, value) {
+      this.fnDefs[name] = value;
+
+      // Add the function to any existing cached view instances
+      for (var viewKey in this._instances) {
+        if (this._instances.hasOwnProperty(viewKey))
+          this._instances[viewKey].fn(name, value);
+      }
+    }
+  };
 }
 Static.prototype.render = function(name, res, model, ns, ctx, status) {
-  var view = this.views[name];
+  var view = this.view._instances[name];
   if (!view) {
-    view = this.views[name] = new View(this.libraries);
+    view = this.view._instances[name] = new View(this.libraries);
     view._root = this.root;
     view._clientName = name;
+
+    for (var key in this.view.fnDefs) {
+      if (this.view.fnDefs.hasOwnProperty(key))
+        view.fn(key, this.view.fnDefs[key]);
+    }
   }
   view.render(res, model, ns, ctx, status, true);
 };


### PR DESCRIPTION
You can now create view functions on `Static` instances and use them in server-side static views.

Usage:

``` js
var staticPages = derby.createStatic(root);
staticPages.view.fn('name', function(...) { ... };
```
