### PR TITLE
Add support for deref operator '^'.

### DIFF
--- a/lib/View.server.js
+++ b/lib/View.server.js
@@ -162,7 +162,6 @@ View.prototype._renderScripts = function(res, ns, ctx, isStatic, jsFile, tail, b
   // Initialization script and Tail
   if (isStatic) return res.end(tail);
 
-console.log(bundle);
   res.end("<script>setTimeout(function(){" +
     "var el = document.getElementById('$_js');" +
     "el.loaded ? init() : el.onload = init;" +


### PR DESCRIPTION
Figured out code to support for #239
With this patch you can use '^' at the beginning of a path to dereference it.

model.set('_error', '_errors.name');
model.set('_data', '_record.name');

``` html
<Body:>
  <!-- some html -->
  <!-- dereference _error to bind to _errors.name here -->
  <app:template data="{_data}" error="{^_error}"/>
  <!-- some more html -->

<template:>
  <input value="{^@data}" class="{#if @error}error{/if}"/>
  <!-- you can use it at the component level as well -->
```
