### PR TITLE
bin/derby: lib require path fixed

### DIFF
--- a/bin/derby
+++ b/bin/derby
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require('./lib/derby');
+require('./../lib/derby');


### PR DESCRIPTION
By default `bin/derby`gives me the following error:

```
module.js:340
    throw err;
          ^
Error: Cannot find module './lib/derby'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (~/node_modules/derby/bin/derby:2:1)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
```

This can be easily fixed with this patch. Although it seems that still doesn't work properly.

```
$ ~/node_modules/derby/bin/derby new first-project
$ echo $?
0
$ ls
$
```

The same problem installing it globally.
