### PR TITLE
Recursive context lookups

### DIFF
--- a/lib/expressions.js
+++ b/lib/expressions.js
@@ -163,7 +163,7 @@ function Context(events, data, meta, parent, segments, alias) {
 Context.prototype.get = function(segments) {
   return lookup(this.data, segments);
 };
-Context.prototype.child = function(expression, alias) {
+Context.prototype.child = function(expression, data, alias) {
   var segments = expression.resolve();
   return new Context(this.events, this.data, this.meta, this, segments, alias);
 };

--- a/test/expression.mocha.js
+++ b/test/expression.mocha.js
@@ -77,7 +77,7 @@ describe('Expression::resolve', function() {
     var expression = expressions.createPathExpression(':color');
     var expression2 = expressions.createPathExpression(':color.name');
     var withExpression = expressions.createPathExpression('_colors.green');
-    var childContext = context.child(withExpression, ':color');
+    var childContext = context.child(withExpression, {}, ':color');
     expect(expression.resolve(childContext)).to.eql(['_colors', 'green']);
     expect(expression2.resolve(childContext)).to.eql(['_colors', 'green', 'name']);
   });
@@ -128,7 +128,7 @@ describe('Expression::get', function() {
   it('gets an alias path expression', function() {
     var expression = expressions.createPathExpression(':color.name');
     var withExpression = expressions.createPathExpression('_colors.green');
-    var childContext = context.child(withExpression, ':color');
+    var childContext = context.child(withExpression, {}, ':color');
     expect(expression.get(childContext)).to.eql('Green');
   });
 
@@ -159,7 +159,7 @@ describe('Expression::get', function() {
   it('gets an fn expression with alias paths', function() {
     var expression = expressions.createPathExpression('plus(:nums.1, :nums.2)');
     var withExpression = expressions.createPathExpression('_nums');
-    var childContext = context.child(withExpression, ':nums');
+    var childContext = context.child(withExpression, {}, ':nums');
     expect(expression.get(childContext)).to.eql(14);
   });
 
@@ -178,6 +178,17 @@ describe('Expression::get', function() {
     var expression2 = expressions.createPathExpression('plus(minus(_nums.3, _nums.2), _nums.1)');
     expect(expression.get(context)).to.eql(6);
     expect(expression2.get(context)).to.eql(15);
+  });
+
+  it('gets a relative path expression with relative/nested contexts with different data', function() {
+    var expression = expressions.createPathExpression('.green.name');
+    var withExpression = expressions.createPathExpression('_colors');
+    var childContext = context.child(withExpression, {
+        green: {
+            name: 'Not green'
+        }
+    });
+    expect(expression.get(childContext)).to.eql('Not green');
   });
 
 });


### PR DESCRIPTION
A mere suggestion (since I lack a full understanding of the grand plan for Derby 0.6): 
I believe it would be nice to be able to send in data into a context that is not the top-level context, which will be data specific to that sub-level (child contexts) context. This will prevent the following scenario from going south (and might also be a neat feature):

Assume you are doing a change upon a specific item. This will/should trigger an update in the view. However, for some reason, the underlying data model is not in sync with this change, but you still need it to happen with the old data (because otherwise you cannot trust that a set of "setDiff" -changes will end up at the specific state you want to end up at). In other words, with this change you cannot trust the underlying data source (e.g. Racer's data model). However, with the change that were originally triggered, you sent along the data you want it to to change to. If you can pass along this data as (sub-) context-specific data, this will solve the issue.

The test should highlight how this scenario should (can) work. I've looked briefly of what'll be needed to fix this and basically the following needs to be fixed (I think):

1) One needs to be able to set context-specific data rather than having the same data at all contexts (child contexts)
2) .get() needs to look at it's specific context first, then, if it doesn't find anything, traverse up for any parent context that may contain this data (and pass along it's sub-context-specific segments appended to the segments one is trying to get).
3) This also means that the segments sent into context should only be the context-specific segments. E.g. if you have a child-context that starts at _colors, then ['green', 'name'] should be the segments sent in, not ['_colors', 'green', 'name'].
4) This means resolve at expressions (e.g. PathExpression.resolve) should not resolve all the way, but rather just send in the end parts of the expression.

It might screw some stuff up, like scenarios where you want to get the full path (like resolve works now). Basically (if I'm not mistaken) some traversing of aliases and such will be handled by the contexts rather than traversed by each expression. However, this might be more desirable (otherwise I have a hard time seeing how this functionality can be implemented without a lot of hacking).

There's a similar issue with Derby 0.5, where I've highlighted scenarios where this causes issues today: https://github.com/codeparty/derby/issues/324
