### PR TITLE
This enables nib for me

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -166,5 +166,6 @@ function stylusCompiler(file, filename, options, cb) {
     .set('filename', filename)
     .set('compress', options.compress)
     .set('include css', true)
+    .import('nib')
     .render(cb);
 }


### PR DESCRIPTION
Without the import statement having the styl-nib-@import only nib fails me where tested (gradients).
Having nib imported thusly instead - et voila, it works

IF ACCEPTING THIS PULL REQUEST:
Please also go to the index.styl and remove the @import 'lib/nib' statement in order to remove unnecessary redundancy
