### PR TITLE
change Head and Styles order

### DIFF
--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -41,8 +41,8 @@ App.prototype._init = function() {
     '<head>' +
       '<meta charset="utf-8">' +
       '<title><view name="{{$render.prefix}}Title"></view></title>' +
-      '<view name="{{$render.prefix}}Styles"></view>' +
       '<view name="{{$render.prefix}}Head"></view>' +
+      '<view name="{{$render.prefix}}Styles"></view>' +
     '</head>' +
     '<body class="{{$bodyClass($render.ns)}}">' +
       '<view name="{{$render.prefix}}Body"></view>'


### PR DESCRIPTION
Often we use Head to add links to css libraries (bootstrap etc.) and Styles to customize these css libraries. So Styles should be after Head. 
