### PR TITLE
allow custom @import paths

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -143,13 +143,16 @@ function cssCompiler(file, filename, options) {
 }
 
 function lessCompiler(file, filename, options) {
+  var paths = (options.lessPaths || []);
+  var dir = path.dirname(filename);
+  if (paths.indexOf(dir) === -1) paths.unshift(dir);
   var parser = new less.Parser({
-    paths: [path.dirname(filename)]
+    paths: paths
   , filename: filename
   , syncImport: true
   });
   var out = {};
-  return parser.parse(file, function(err, tree) {
+  parser.parse(file, function(err, tree) {
     if (err) throw err;
     out.css = tree.toCSS(options);
   });


### PR DESCRIPTION
allows a main.less file to in an app directory to replace the default shipped with a component without requiring the developer to `cp *.less` to make @import work.
