### PR TITLE
bugfix loadStylesSync ran once for every compiler

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -122,18 +122,30 @@ function loadStylesSync(app, sourceFilename, options) {
   options || (options = {compress: util.isProduction});
   var css = '';
   var files = [];
-  app.styleExtensions.forEach(function(extension) {
-    var compiler = app.compilers[extension];
-    if (!compiler) {
-      throw new Error('Unable to find compiler for: ' + extension);
+  var extension = sourceFilename.match(/\.[0-9a-z]+$/i);
+  if (!extension) {
+    var files = app.styleExtensions
+      .map(function (ext) {
+        return sourceFilename + ext;
+      })
+      .filter(function (path) {
+        return fs.existsSync(path);
+      });
+    if (files == null || files.length < 1) {
+      throw new Error('Unable to parse extension from ' + sourceFilename);
     }
-    var data = importFileSync(sourceFilename, extension);
-    // Ignore if style file doesn't exist
-    if (!data) return '';
-    var compiled = compiler(data.file, data.filename, options);
-    css += compiled.css;
-    files = files.concat(compiled.files);
-  });
+    return loadStylesSync(app, files[0], options);
+  }
+  extension = extension[0];
+  var compiler = app.compilers[extension];
+  if (app.styleExtensions.indexOf(extension) === -1 || !compiler) {
+    throw new Error('Unable to find compiler for: ' + extension);
+  }
+  var data = importFileSync(sourceFilename, extension);
+  if (!data) return '';
+  var compiled = compiler(data.file, data.filename, options);
+  css += compiled.css;
+  files = files.concat(compiled.files);
   return {css: css, files: files};
 }
 


### PR DESCRIPTION
don't know when this was introduced (can't bisect on test suite) so opted for rewrite

loadStylesSync was previously calling each compiler on each asset file
