### PR TITLE
mocha's exit code should be retuned on `npm test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha test/all/*.mocha.js; ./node_modules/.bin/jshint lib/*.js test/*.js"
+    "test": "./node_modules/.bin/jshint lib/*.js test/*.js && ./node_modules/.bin/mocha test/all/*.mocha.js"
   },
   "dependencies": {
     "derby-parsing": "^0.3.2",


### PR DESCRIPTION
instead of silently swallowing mocha's exit code and returning jshint's