### PR TITLE
Refactor 2b763e3 for readability

### DIFF
--- a/lib/Dom.js
+++ b/lib/Dom.js
@@ -27,11 +27,19 @@ Dom.prototype._listenerIndex = function(domListener) {
   return -1;
 };
 
-Dom.prototype.addListener = function(type, target, listener, useCapture) {
-  if (typeof target === 'function') {
-    useCapture = listener;
-    listener = target;
-    target = document;
+Dom.prototype.addListener = function() {
+  var args = Array.prototype.slice.call(arguments);
+  var type, target, listener, useCapture;
+  if (typeof args[1] === 'function') {
+    target     = document;
+    type       = args[0];
+    listener   = args[1];
+    useCapture = args[2];
+  } else {
+    type       = args[0];
+    target     = args[1];
+    listener   = args[2];
+    useCapture = args[3];
   }
   var domListener = new DomListener(type, target, listener, useCapture);
   if (-1 === this._listenerIndex(domListener)) {
@@ -42,11 +50,19 @@ Dom.prototype.addListener = function(type, target, listener, useCapture) {
 };
 Dom.prototype.on = Dom.prototype.addListener;
 
-Dom.prototype.once = function(type, target, listener, useCapture) {
-  if (typeof target === 'function') {
-    useCapture = listener;
-    listener = target;
-    target = document;
+Dom.prototype.once = function() {
+  var args = Array.prototype.slice.call(arguments);
+  var type, target, listener, useCapture;
+  if (typeof args[1] === 'function') {
+    target     = document;
+    type       = args[0];
+    listener   = args[1];
+    useCapture = args[2];
+  } else {
+    type       = args[0];
+    target     = args[1];
+    listener   = args[2];
+    useCapture = args[3];
   }
   this.addListener(type, target, wrappedListener, useCapture);
   var dom = this;
@@ -56,11 +72,19 @@ Dom.prototype.once = function(type, target, listener, useCapture) {
   }
 };
 
-Dom.prototype.removeListener = function(type, target, listener, useCapture) {
-  if (typeof target === 'function') {
-    useCapture = listener;
-    listener = target;
-    target = document;
+Dom.prototype.removeListener = function() {
+  var args = Array.prototype.slice.call(arguments);
+  var type, target, listener, useCapture;
+  if (typeof args[1] === 'function') {
+    target     = document;
+    type       = args[0];
+    listener   = args[1];
+    useCapture = args[2];
+  } else {
+    type       = args[0];
+    target     = args[1];
+    listener   = args[2];
+    useCapture = args[3];
   }
   var domListener = new DomListener(type, target, listener, useCapture);
   domListener.remove();


### PR DESCRIPTION
I noticed myself performing repeated regressive saccades due to the
parameter renaming in the if-statement which this commit removes.

The arguments array is copied to remain strictness-neutral, in keeping
with the existing implementation.

The choice of argument assignment on a type check makes sense as the
`Dom` methods are expected to be frequently called with only two or three
arguments. Note that `DomListener` effectively shims the proposed
[DOM Level 3 Events](https://dvcs.w3.org/hg/dom3events/raw-file/tip/html/DOM3-Events.html) specification by explicitly setting `useCapture`
to `false` when undefined for compatibility with [DOM 2](http://www.w3.org/TR/DOM-Level-2-Events/events.html) browsers.
