### PR TITLE
Fix for path issue on finding components

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -155,7 +155,7 @@ App.prototype.component = function(viewName, constructor) {
   // Load template view from filename
   if (constructor.prototype.view) {
     var viewFilename = constructor.prototype.view;
-    viewName = path.basename(viewFilename, '.html');
+    viewName = basename(viewFilename, '.html');
     this.loadViews(viewFilename, viewName);
 
   } else if (!viewName) {
@@ -187,4 +187,9 @@ function extendComponent(constructor) {
   var oldPrototype = constructor.prototype;
   constructor.prototype = new Component();
   util.mergeInto(constructor.prototype, oldPrototype);
+}
+
+function basename(filename, ext) {
+  filename = filename.replace(/\\/g, '/');
+  return path.basename(filename, ext);
 }


### PR DESCRIPTION
This is a fix for #403, maybe it is temporary solution, until browserify will fix this.
