### PR TITLE
make resolve.sync traces more helpful

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -18,9 +18,15 @@ exports.htmlCompiler = htmlCompiler;
 function loadViewsSync(app, sourceFilename, namespace) {
   var views = [];
   var files = [];
-  var resolved = resolve.sync(sourceFilename, {extensions: app.viewExtensions, packageFilter: deleteMain});
-  if (!resolved) {
-    throw new Error('View template file not found: ' + sourceFilename);
+  var resolved;
+  try {
+    resolved = resolve.sync(sourceFilename, {extensions: app.viewExtensions, packageFilter: deleteMain});
+  } catch (e) {
+    throw new Error('View template not found at `' +
+                    path.resolve(sourceFilename) +
+                    'with extension in `' +
+                    app.viewExtensions +
+                    '`.');
   }
 
   var file = fs.readFileSync(resolved, 'utf8');
@@ -113,9 +119,15 @@ function parseViews(namespace, file, filename, extensions) {
 
 function loadStylesSync(app, sourceFilename, options) {
   options || (options = {compress: util.isProduction});
-  var resolved = resolve.sync(sourceFilename, {extensions: app.styleExtensions, packageFilter: deleteMain});
-  if (!resolved) {
-    throw new Error('Style file not found: ' + sourceFilename);
+  var resolved;
+  try {
+    resolved = resolve.sync(sourceFilename, {extensions: app.styleExtensions, packageFilter: deleteMain});
+  } catch (e) {
+    throw new Error('Style not found at `' +
+                    path.resolve(sourceFilename) +
+                    'with extension in `' +
+                    app.styleExtensions +
+                    '`. Stylesheet compliers were extracted to derby-stylus and derby-less');
   }
   var extension = path.extname(resolved);
   var compiler = app.compilers[extension];

--- a/lib/files.js
+++ b/lib/files.js
@@ -21,7 +21,7 @@ function loadViewsSync(app, sourceFilename, namespace) {
   var resolved;
   try {
     resolved = resolve.sync(sourceFilename, {extensions: app.viewExtensions, packageFilter: deleteMain});
-  } catch (e) {
+  } catch (err) {
     throw new Error('View template not found at `' +
                     path.resolve(sourceFilename) +
                     'with extension in `' +
@@ -122,7 +122,7 @@ function loadStylesSync(app, sourceFilename, options) {
   var resolved;
   try {
     resolved = resolve.sync(sourceFilename, {extensions: app.styleExtensions, packageFilter: deleteMain});
-  } catch (e) {
+  } catch (err) {
     throw new Error('Style not found at `' +
                     path.resolve(sourceFilename) +
                     'with extension in `' +


### PR DESCRIPTION
For folks who didn't notice the extraction of derby-stylus and derby-less, the resolve.sync calls throw cryptic errors. This PR catches [the resolve error](https://github.com/substack/node-resolve/blob/0.6.3/lib/sync.js#L32) and re-throws with the searched extensions.

I know the try-catch is ugly, but execution never reaches `if (!resolved)` is because of the error thrown by `resolve`.

Followup to comment on #415.