### PR TITLE
[components] Fix setting attributes into scoped model on component init

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -100,6 +100,8 @@ function setAttributes(context, model) {
     );
     if (segments) {
       model.root.ref(model._at + '.' + key, segments.join('.'));
+    } else if (attribute instanceof templates.ParentWrapper) {
+      model.set(key, expressions.renderValue(attribute, context));
     } else {
       model.set(key, attribute);
     }


### PR DESCRIPTION
Related to #418
There are couple of cases when attribute's original path can not be resolved (when attribute is ParentWrapper):
1. When passing the same attribute from one component into another, like described in #418.
2. When having some complicated argument's value, like

``` html
    <view name='payment' payload='{{ { price: 500, params: #root._page.paymentParams } }}'>
```

**currently those kind of attributes end up being ParentWrappers inside component's model**

While there is probably a solution to the 1st case, I don't think there is a simple solution to the 2nd one (it can be implemented in theory though - by automatically creating a reactive functions for this kind of argument values or something like that).
So when ParentWrapper attribute fails to resolve it's original path for creating a ref we should at least init component's model with its renderValue.
