### PR TITLE
writeScripts should have optional `options`

### DIFF
--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -120,6 +120,7 @@ App.prototype.bundle = function(store, options, cb) {
 };
 
 App.prototype.writeScripts = function(store, dir, options, cb) {
+  if (arguments.length === 3) (cb = options) && (options = {});
   var app = this;
   this.bundle(store, options, function(err, source, map) {
     if (err) return cb(err);


### PR DESCRIPTION
Passing 3 arguments instead of 4 to `writeScripts` should not fail silently.

People who aren't using coffeescript probably don't need to pass an options object at all.
