### PR TITLE
App.prototype._finishInit should handle unexpected null

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -58,7 +58,7 @@ App.prototype._finishInit = function() {
   try {
     data = JSON.parse(script.nextSibling.innerHTML);
   } catch (err) {
-    var json = script.nextSibling && script.nextSibling.innerHTML;
+    var json = ((script || {}).nextSibling || {}).innerHTML;
     this.emit('error', err, json);
   }
   util.isProduction = data.nodeEnv === 'production';


### PR DESCRIPTION
App.prototype._finishInit should always emit the error even if `script` is undefined.

---
This idiom is similar to the accessor variant of coffeescript's existential operator
```coffeescript
json = script?.nextSibling?.innerHTML
```
but any falsey value along the chain will produce and end result of `undefined` while the coffeescript version explicity checks `null` and `undefined` instead of all falsey values.

^ for my own reference, folks.