### PR TITLE
an App without a `name` is a sad thing

### DIFF
--- a/lib/Derby.js
+++ b/lib/Derby.js
@@ -20,6 +20,7 @@ Derby.prototype.Page = Page;
 Derby.prototype.Component = components.Component;
 
 Derby.prototype.createApp = function(name, filename) {
+  if (typeof name !== 'string' && name.length < 1) throw name;
   return new App(this, name, filename);
 };
 


### PR DESCRIPTION
People [like](https://github.com/codeparty/derby-starter/blob/master/lib/server.js) [calling](https://github.com/derbyparty/derby-boilerplate/blob/master/src/server/error/index.js#L4)  createApp with no arguments. Is this ok for static apps? Causes no end of pain for regular ones, if forgotten. Is there anything wrong with forcing people to name their static apps too?

This might be better placed in `lib/App.js`, or somewhere else for that matter. Let me know.