### PR TITLE
Fix live update of styles.

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -220,6 +220,11 @@ App.prototype._autoRefresh = function() {
     var ns = app.model.get('$render.ns');
     app.page.render(ns);
   });
+  this.model.channel.on('derby:refreshStyles', function(data) {
+    var styleElement = document.querySelector('style[data-filename="' +
+      data.filename + '"]');
+    if (styleElement) styleElement.innerHTML = data.styles;
+  });
   function registerClient() {
     var data = {name: app.name, hash: '{{DERBY_SCRIPT_HASH}}'};
     app.model.channel.send('derby:app', data, function(err) {

--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -204,7 +204,13 @@ App.prototype.loadStyles = function(filename, options) {
 
 App.prototype._loadStyles = function(filename, options) {
   var styles = files.loadStylesSync(this, filename, options);
-  this.views.register(filename, '<style>' + styles.css + '</style>', {serverOnly: true});
+  // Styles are serverOnly. So in order to achieve Live updates in development
+  // we need to mark the style tag to be able to manually find and replace it.
+  this.views.register(
+    filename
+  , '<style data-filename="' + filename + '">' + styles.css + '</style>'
+  , {serverOnly: true}
+  );
   this._watchStyles(styles.files, filename, options);
 };
 
@@ -226,7 +232,7 @@ App.prototype._watchStyles = function(filenames, filename, options) {
     watcher.close();
     app._loadStyles(filename, options);
     app._updateScriptViews();
-    app._refreshClients();
+    app._refreshStyles(filename);
   });
 };
 
@@ -272,5 +278,18 @@ App.prototype._refreshClients = function() {
   var data = this.views.serialize({minify: true});
   for (var id in this.clients) {
     this.clients[id].channel.send('derby:refreshViews', data);
+  }
+};
+
+App.prototype._refreshStyles = function(filename) {
+  if (!this.clients) return;
+  var data = { filename: filename };
+  var source = this.views.find(filename).source;
+  // Get <styles> tag content
+  var matchStyles = source.match(/<style[^>]*>([^]*)<\/style>/);
+  if (!matchStyles) return;
+  data.styles = matchStyles[1];
+  for (var id in this.clients) {
+    this.clients[id].channel.send('derby:refreshStyles', data);
   }
 };


### PR DESCRIPTION
Recent changes to derby introduced ```serverOnly``` templates which can't be updated on the client and ```Styles:``` is one of them. 

This pull request fixes the autoreload issues with styles by marking ```<style>``` tag with related filename and replacing its content when the time comes to update it.