### PR TITLE
set 'usePolling: false' to make watching changes more efficient

### DIFF
--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -210,7 +210,7 @@ App.prototype._loadStyles = function(filename, options) {
 
 App.prototype._watchViews = function(filenames, filename, namespace) {
   var app = this;
-  var watcher = chokidar.watch(filenames);
+  var watcher = chokidar.watch(filenames, { usePolling: false });
   watcher.on('change', function() {
     watcher.close();
     app.loadViews(filename, namespace);
@@ -221,7 +221,7 @@ App.prototype._watchViews = function(filenames, filename, namespace) {
 
 App.prototype._watchStyles = function(filenames, filename, options) {
   var app = this;
-  var watcher = chokidar.watch(filenames);
+  var watcher = chokidar.watch(filenames, { usePolling: false });
   watcher.on('change', function() {
     watcher.close();
     app._loadStyles(filename, options);
@@ -233,7 +233,7 @@ App.prototype._watchStyles = function(filenames, filename, options) {
 App.prototype._watchBundle = function(filenames) {
   if (!process.send) return;
   var app = this;
-  var watcher = chokidar.watch(filenames);
+  var watcher = chokidar.watch(filenames, { usePolling: false });
   watcher.on('change', function() {
     watcher.close();
     process.send({type: 'reload'});


### PR DESCRIPTION
I noticed that Derby was using CPU quite a bit and it lead to chokidar which polled files for changes.

`usePolling: false` makes chokidar not to poll but to use more efficient methods (`fs.watch` instead of `fs.watchFile`).

YMMV. Might not work across network filesystems.