### PR TITLE
Remove sourceMaps from production (by default)

### DIFF
--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -149,7 +149,11 @@ App.prototype.writeScripts = function(store, dir, options, cb) {
     app.scriptFilename = base + '.js';
     app.scriptMapFilename = base + '.map.json';
     fs.writeFileSync(app.scriptFilename, source, 'utf8');
-    fs.writeFileSync(app.scriptMapFilename, map, 'utf8');
+
+    if (!util.isProduction || options.sourceMapsInProduction) {
+      fs.writeFileSync(app.scriptMapFilename, map, 'utf8');
+    }
+
     cb();
   });
 };


### PR DESCRIPTION
I think it's insecure to generate source maps in production by default.
