### PR TITLE
Add component level stylesheet setting

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -194,6 +194,12 @@ App.prototype.component = function(viewName, constructor) {
     }
   }
 
+  // Load style from component prototype property if existing
+  if (constructor.prototype.style) {
+    var styleFileName = constructor.prototype.style;
+    this.loadStyles(styleFileName);
+  }
+
   // Associate the appropriate view with the component type
   var view = this.views.find(viewName);
   if (!view) {


### PR DESCRIPTION
Useful for defining styles within a component rather than having all in a separate global file/folder

Basically remove the need for the following plugin: https://github.com/BBWeb/d-component-styles
