### PR TITLE
Emit 'bundle' event on app

### DIFF
--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -77,6 +77,7 @@ App.prototype.createPage = function(req, res, next) {
 };
 
 App.prototype.bundle = function(store, options, cb) {
+  var app = this;
   if (typeof options === 'function') {
     cb = options;
     options = null;
@@ -105,8 +106,8 @@ App.prototype.bundle = function(store, options, cb) {
     bundle.on('file', function(filename) {
       bundleFiles.push(filename);
     });
+    app.emit('bundle', bundle);
   });
-  var app = this;
   store.bundle(app.filename, options, function(err, source, map) {
     if (err) return cb(err);
     app.scriptHash = crypto.createHash('md5').update(source).digest('hex');


### PR DESCRIPTION
This will allow derby plugins (`app.use()`) to access browserify instance to bundle in additional client-side scripts / register additional transforms.