### PR TITLE
Components attributes binding fix (passing attributes which are array items)

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -99,7 +99,7 @@ function setAttributes(context, model) {
       attribute.expression.pathSegments(context)
     );
     if (segments) {
-      model.root.ref(model._at + '.' + key, segments.join('.'));
+      model.root.ref(model._at + '.' + key, segments.join('.'), {updateIndices: true});
     } else {
       model.set(key, attribute);
     }


### PR DESCRIPTION
This is fix for the issue https://github.com/derbyjs/derby/issues/482. Just added updateIndices option to component attribute reference.