### PR TITLE
Cross browser fixes

### DIFF
--- a/lib/documentListeners.js
+++ b/lib/documentListeners.js
@@ -26,6 +26,18 @@ function inputValue(input) {
 function addDocumentListeners(doc) {
   doc.addEventListener('input', documentInput, true);
   doc.addEventListener('change', documentChange, true);
+
+  //listen to more events for versions of IE with buggy input event implementations
+  if (parseFloat(window.navigator.appVersion.split("MSIE ")[1]) <= 9) {
+    // We're listening on selectionchange because there's no other event emitted when
+    // the user clicks 'delete' from a context menu when right clicking on selected text.
+    // So although this event fires overly aggressively, it's the only real way
+    // to ensure that we can detect all changes to the input value in IE <= 9
+    doc.addEventListener('selectionchange', function(e){
+      if(document.activeElement)
+        documentInput({target: document.activeElement}); // selectionchange evts don't have the e.target we need
+    }, true);
+  }
 }
 
 function documentInput(e) {

--- a/lib/documentListeners.js
+++ b/lib/documentListeners.js
@@ -83,16 +83,18 @@ function documentInput(e) {
   }
 }
 
+function applyAttributeBinding(target, prop) {
+  var binding = target.$bindAttributes && target.$bindAttributes[prop];
+  if (!binding || binding.isUnbound()) return;
+  binding.template.expression.set(binding.context, target[prop]);
+}
+
 function documentChange(e) {
   var target = e.target;
-  var bindAttributes = target.$bindAttributes;
 
-  if (target.tagName === 'INPUT' && bindAttributes) {
-    for (var attr in bindAttributes) {
-      var binding = bindAttributes[attr];
-      if (!binding.isUnbound())
-        binding.template.expression.set(binding.context, target[attr]);
-    }
+  if (target.tagName === 'INPUT') {
+    applyAttributeBinding(target, 'checked');
+    applyAttributeBinding(target, 'value');
   } else if (target.tagName === 'SELECT') {
     setOptionBindings(target);
   }

--- a/lib/documentListeners.js
+++ b/lib/documentListeners.js
@@ -68,11 +68,12 @@ function documentChange(e) {
   var target = e.target;
   var bindAttributes = target.$bindAttributes;
 
-  if (target.tagName === 'INPUT') {
-    var binding = target.$bindAttributes && target.$bindAttributes.checked;
-    if (!binding || binding.isUnbound()) return;
-    binding.template.expression.set(binding.context, target.checked);
-
+  if (target.tagName === 'INPUT' && bindAttributes) {
+    for (var attr in bindAttributes) {
+      var binding = bindAttributes[attr];
+      if (!binding.isUnbound())
+        binding.template.expression.set(binding.context, target[attr]);
+    }
   } else if (target.tagName === 'SELECT') {
     setOptionBindings(target);
   }

--- a/lib/documentListeners.js
+++ b/lib/documentListeners.js
@@ -6,7 +6,7 @@ exports.inputSupportsSelection = inputSupportsSelection;
 // http://www.whatwg.org/specs/web-apps/current-work/multipage/the-input-element.html#do-not-apply
 // TODO: Date types support
 function inputSupportsSelection(input) {
-  var type = input.getAttribute('type');
+  var type = input.type;
   return (
     type === 'text' ||
     type === 'search' ||

--- a/lib/documentListeners.js
+++ b/lib/documentListeners.js
@@ -26,8 +26,12 @@ function inputValue(input) {
 if ((typeof window) != "undefined" && window.navigator.appVersion.indexOf("Trident") != -1) {
   //for some reason valueAsNumber returns NaN for number inputs in IE
   //until a new IE version that handles this is released, parse input.value as a fallback
+  oldInputValue = inputValue;
   inputValue = function(input) {
-    return inputIsNumberValue(input) ? parseFloat(input.value) : input.value
+    if (input.getAttribute('type') == 'number')
+      return inputIsNumberValue(input) ? parseFloat(input.value) : input.value
+    else
+      return oldInputValue.apply(this, arguments);
   }
 }
 

--- a/lib/documentListeners.js
+++ b/lib/documentListeners.js
@@ -23,21 +23,10 @@ function inputValue(input) {
   return inputIsNumberValue(input) ? input.valueAsNumber : input.value;
 }
 
-if ((typeof window) != "undefined" && window.navigator.appVersion.indexOf("Trident") != -1) {
-  //for some reason valueAsNumber returns NaN for number inputs in IE
-  //until a new IE version that handles this is released, parse input.value as a fallback
-  oldInputValue = inputValue;
-  inputValue = function(input) {
-    if (input.getAttribute('type') == 'number')
-      return inputIsNumberValue(input) ? parseFloat(input.value) : input.value
-    else
-      return oldInputValue.apply(this, arguments);
-  }
-}
-
 function addDocumentListeners(doc) {
   doc.addEventListener('input', documentInput, true);
   doc.addEventListener('change', documentChange, true);
+
 
   //listen to more events for versions of IE with buggy input event implementations
   if (parseFloat(window.navigator.appVersion.split("MSIE ")[1]) <= 9) {
@@ -46,9 +35,27 @@ function addDocumentListeners(doc) {
     // So although this event fires overly aggressively, it's the only real way
     // to ensure that we can detect all changes to the input value in IE <= 9
     doc.addEventListener('selectionchange', function(e){
-      if(document.activeElement)
+      if (document.activeElement) {
         documentInput({target: document.activeElement}); // selectionchange evts don't have the e.target we need
+      }
     }, true);
+  }
+
+
+  //for some reason valueAsNumber returns NaN for number inputs in IE
+  //until a new IE version that handles this is released, parse input.value as a fallback
+  var input = document.createElement('input');
+  input.type = 'number';
+  input.value = '101';
+  if (input.valueAsNumber !== input.valueAsNumber) {
+    oldInputValue = inputValue;
+    inputValue = function(input) {
+      if (input.type === 'number') {
+        return inputIsNumberValue(input) ? parseFloat(input.value) : input.value
+      } else {
+        return oldInputValue.apply(this, arguments);
+      }
+    }
   }
 }
 

--- a/lib/documentListeners.js
+++ b/lib/documentListeners.js
@@ -6,7 +6,7 @@ exports.inputSupportsSelection = inputSupportsSelection;
 // http://www.whatwg.org/specs/web-apps/current-work/multipage/the-input-element.html#do-not-apply
 // TODO: Date types support
 function inputSupportsSelection(input) {
-  var type = input.type;
+  var type = input.getAttribute('type');
   return (
     type === 'text' ||
     type === 'search' ||

--- a/lib/documentListeners.js
+++ b/lib/documentListeners.js
@@ -23,6 +23,14 @@ function inputValue(input) {
   return inputIsNumberValue(input) ? input.valueAsNumber : input.value;
 }
 
+if ((typeof window) != "undefined" && window.navigator.appVersion.indexOf("Trident") != -1) {
+  //for some reason valueAsNumber returns NaN for number inputs in IE
+  //until a new IE version that handles this is released, parse input.value as a fallback
+  inputValue = function(input) {
+    return inputIsNumberValue(input) ? parseFloat(input.value) : input.value
+  }
+}
+
 function addDocumentListeners(doc) {
   doc.addEventListener('input', documentInput, true);
   doc.addEventListener('change', documentChange, true);

--- a/lib/documentListeners.js
+++ b/lib/documentListeners.js
@@ -46,7 +46,7 @@ function addDocumentListeners(doc) {
   //until a new IE version that handles this is released, parse input.value as a fallback
   var input = document.createElement('input');
   input.type = 'number';
-  input.value = '101';
+  input.value = '7';
   if (input.valueAsNumber !== input.valueAsNumber) {
     oldInputValue = inputValue;
     inputValue = function(input) {

--- a/test/browser/bindings.mocha.js
+++ b/test/browser/bindings.mocha.js
@@ -330,7 +330,8 @@ function expectHtml(fragment, html) {
 
 function fragmentHtml(fragment) {
   var clone = document.importNode(fragment, true);
-  var treeWalker = document.createTreeWalker(clone, NodeFilter.SHOW_COMMENT);
+  // last two arguments for createTreeWalker are required in IE unfortunately
+  var treeWalker = document.createTreeWalker(clone, NodeFilter.SHOW_COMMENT, null, false);
   var toRemove = [];
   for (var node; node = treeWalker.nextNode();) {
     toRemove.push(node);


### PR DESCRIPTION
Bugs that were fixed:

* In any version of Trident, number inputs' `valueAsNumber` property are always `NaN` for some reason, so in those situations I fell back onto getting the value from `parseFloat(input.value)`
* Sliders in IE fire `change` events instead of `input` events when they change, so I added code for handling those cases into the `change` listener.
* Deleting text in IE9 doesn't fire `change` or `input` events, so I added listeners for `selectionchange` events. It fires aggressively but it's the only sane way of ensuring we catch any field updates.
* One of the test cases didn't work in IE due to required arguments missing, so I fixed it