### PR TITLE
Fixed bug where number inputs would be cast to strings sometimes

### DIFF
--- a/lib/documentListeners.js
+++ b/lib/documentListeners.js
@@ -83,16 +83,11 @@ function documentInput(e) {
   }
 }
 
-function applyAttributeBinding(target, prop) {
+function applyAttributeBinding(target, prop, getter) {
   var binding = target.$bindAttributes && target.$bindAttributes[prop];
   if (!binding || binding.isUnbound()) return;
 
-  var value;
-  if (prop === 'value') {
-    value = inputValue(target);
-  } else {
-    value = target[prop];
-  }
+  var value = (getter) ? getter(target) : target[prop];
   binding.template.expression.set(binding.context, value);
 }
 
@@ -101,7 +96,7 @@ function documentChange(e) {
 
   if (target.tagName === 'INPUT') {
     applyAttributeBinding(target, 'checked');
-    applyAttributeBinding(target, 'value');
+    applyAttributeBinding(target, 'value', inputValue);
   } else if (target.tagName === 'SELECT') {
     setOptionBindings(target);
   }

--- a/lib/documentListeners.js
+++ b/lib/documentListeners.js
@@ -86,7 +86,14 @@ function documentInput(e) {
 function applyAttributeBinding(target, prop) {
   var binding = target.$bindAttributes && target.$bindAttributes[prop];
   if (!binding || binding.isUnbound()) return;
-  binding.template.expression.set(binding.context, target[prop]);
+
+  var value;
+  if (prop === 'value') {
+    value = inputValue(target);
+  } else {
+    value = target[prop];
+  }
+  binding.template.expression.set(binding.context, value);
 }
 
 function documentChange(e) {


### PR DESCRIPTION
/cc @nateps @enjalot 

This was a regression due to my cross browser changes. The solution was to get the value from `inputValue(target)` when working with a value binding rather than setting it directly, since `inputValue(target)` ensures that it gets cast to the correct type in the case of number fields.

(fixes #492)