### PR TITLE
Improvement. Do not display system filepath to css file in production

### DIFF
--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -211,14 +211,41 @@ App.prototype.loadStyles = function(filename, options) {
 
 App.prototype._loadStyles = function(filename, options) {
   var styles = files.loadStylesSync(this, filename, options);
-  // Styles are serverOnly. So in order to achieve Live updates in development
-  // we need to mark the style tag to be able to manually find and replace it.
-  var source =
-    '<style data-filename="' + filename + '">' +
-      styles.css +
-    '</style>';
-  this.views.register(filename, source, {serverOnly: true});
-  if (!util.isProduction) this._watchStyles(styles.files, filename, options);
+
+  var source = '';
+  source += '<style';
+
+  /**
+   * Styles are serverOnly. So in order to achieve Live updates in development
+   * we need to mark the style tag to be able to manually find and replace it.
+   */
+
+  if (!util.isProduction) {
+    /**
+     * Mark the path to file as an attribute
+     * Used in development to add event watchers and autorefreshing of styles
+     *
+     * Critical moment. Do not display filepath in production.
+     * TODO: use site path instead
+     *
+     * SEE: local file, method this._watchStyles
+     * SEE: file ./App.js, method App._autoRefresh()
+     */
+    source += ' data-filename="' + filename + '"';
+  }
+
+  source += '>';
+  source += styles.css;
+  source += '</style>';
+
+  this.views.register(filename, source, {
+    serverOnly: true
+  });
+
+  if (!util.isProduction) {
+    this._watchStyles(styles.files, filename, options);
+  }
+
   return styles;
 };
 


### PR DESCRIPTION
In producton I have the next HTML structure in head tag
```html
<head>
  <style data-filename="/home/www/project-name/apps/app-name/styles/../../../public/css/bootstrap.css">
  <style data-filename="/home/www/project-name/apps/app-name/styles/index.styl">
  <style data-filename="/home/www/project-name/components/component-name/index.styl">
</head>
```

I think, it's not correct to show file system path. It could be used in dev environment, but not in prod.
Maybe method _loadStyles should be improved for using file location for site.