### PR TITLE
keep ref to binding wrappers

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -226,8 +226,15 @@ Page.prototype._addContextListeners = function(eventModel) {
 
 function addDependencies(eventModel, expression, binding) {
   var bindingWrapper = new BindingWrapper(eventModel, expression, binding);
+  if(!util.isProduction) {
+    if(!eventModel.bindingWrappers) {
+      eventModel.bindingWrappers = []
+    }
+    eventModel.bindingWrappers.push(bindingWrapper);
+  }
   bindingWrapper.updateDependencies();
 }
+
 
 // The code here uses object-based set pattern where objects are keyed using
 // sequentially generated IDs.


### PR DESCRIPTION
I doubt this is the best way to do this, but if we have a handle on the bindingwrappers we can easily iterate over them and list them out or visualize them.
This script can be copy pasted into the console of a derby app running with this patch:
https://gist.github.com/enjalot/df8b4cab9c8b508325aa

the output on the sink example (with different color choices):
![screen shot 2015-04-22 at 9 49 19 pm](https://cloud.githubusercontent.com/assets/96189/7291336/aee1e0a8-e943-11e4-8d3b-99e96c5591b8.png)

![screen shot 2015-04-22 at 11 06 22 pm](https://cloud.githubusercontent.com/assets/96189/7291369/44af0782-e944-11e4-87cc-61289164782a.png)

these turn more red the more times the bindings are updated.
Is there a better way to walk all the bindings and get the elements, expressions and binding id's?
