### PR TITLE
Emit rendered page with render output

### DIFF
--- a/lib/Page.server.js
+++ b/lib/Page.server.js
@@ -24,7 +24,9 @@ Page.prototype.render = function(status, ns) {
     if (err) return page.emit('error', err);
     var scripts = '<script async src="' + page.app.scriptUrl + '"></script>' +
       '<script type="application/json">' + stringifyBundle(bundle) + '</script>';
-    page.res.send(pageHtml + scripts + tailHtml);
+    var renderedPage = pageHtml + scripts + tailHtml;
+    page.res.send(renderedPage);
+    page.app.emit('pageRendered', page, renderedPage);
     page.app.emit('routeDone', page, 'render');
   });
 };


### PR DESCRIPTION
Patch created for the `derby-cache` [module](https://github.com/mattbrun/derby-cache).
It allows anyone listening on the app `pageRendered` event to use the rendered page output.