### PR TITLE
Do not render when model has errored

### DIFF
--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -71,7 +71,10 @@ App.prototype.createPage = function(req, res, next) {
   this.emit('model', model);
   var page = new this.Page(this, model, req, res);
   if (next) {
-    model.on('error', next);
+    model.on('error', function(err){
+      model.hasErrored = true;
+      next(err);
+    });
     page.on('error', next);
   }
   return page;

--- a/lib/Page.server.js
+++ b/lib/Page.server.js
@@ -21,6 +21,7 @@ Page.prototype.render = function(status, ns) {
   var page = this;
   this.model.destroy('$components');
   this.model.bundle(function(err, bundle) {
+    if (page.model.hasErrored) return;
     if (err) return page.emit('error', err);
     var scripts = '<script async src="' + page.app.scriptUrl + '"></script>' +
       '<script type="application/json">' + stringifyBundle(bundle) + '</script>';


### PR DESCRIPTION
@nateps 

As we discussed, track a bit on the model when we handle a model error.

Then, in the Page.render check for this bit so we don't render the page