### PR TITLE
make components written in LiveScript work

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -161,10 +161,12 @@ SingletonComponentFactory.prototype.init = function(context) {
 SingletonComponentFactory.prototype.create = function() {};
 
 App.prototype.component = function(viewName, constructor) {
-  if (typeof viewName === 'function') {
+  if (viewName && (typeof viewName === 'function' || typeof viewName === 'object')) {
     constructor = viewName;
     viewName = null;
   }
+
+  constructor = extractLiveScriptConstructor(constructor);
 
   // Inherit from Component
   extendComponent(constructor);
@@ -196,6 +198,18 @@ App.prototype.component = function(viewName, constructor) {
   // Make chainable
   return this;
 };
+
+
+function extractLiveScriptConstructor(constructor) {
+  if (typeof constructor === 'object') {
+    var keys = Object.keys(constructor);
+    if (keys.length == 1) {
+      return constructor[keys[0]];
+    }
+  }
+  return constructor;
+}
+
 
 function extendComponent(constructor) {
   // Don't do anything if the constructor already extends Component


### PR DESCRIPTION
Derby components written in LiveScript as classes won't work without this patch.