### PR TITLE
Node v6 compatibility 

### DIFF
--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -34,7 +34,7 @@ App.prototype._init = function() {
   this.viewExtensions = VIEW_EXTENSIONS.slice();
   this.compilers = util.copyObject(COMPILERS);
 
-  this.serializedDir = path.dirname(this.filename) + '/derby-serialized';
+  this.serializedDir = path.dirname(this.filename || '') + '/derby-serialized';
   this.serializedBase = this.serializedDir + '/' + this.name;
   if (fs.existsSync(this.serializedBase + '.json')) {
     this.deserialize();


### PR DESCRIPTION
node v6 changed path.dirname to throw if the input path is not a strng.


In versions of node < 5, `path.dirname(undefined)` is equivalent to `path.dirname('')`. 
By falling back to `''` before calling dirname, we are able to maintain consistent behaviour across all versions of node