### PR TITLE
fixed extendComponent(): it now also works with ES6 classes

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -199,9 +199,14 @@ App.prototype.component = function(viewName, constructor) {
 
 function extendComponent(constructor) {
   // Don't do anything if the constructor already extends Component
-  if (constructor.prototype instanceof Component) return;
-  // Otherwise, replace its prototype with an instance of Component
-  var oldPrototype = constructor.prototype;
-  constructor.prototype = new Component();
-  util.mergeInto(constructor.prototype, oldPrototype);
+  if (constructor.prototype instanceof Component)
+    return;
+
+  // Otherwise, add an instance of Component to its prototype chain
+  var c = constructor.prototype;
+  for (var p = Object.getPrototypeOf(c); p !== Object.prototype && p !== Function.prototype; p = Object.getPrototypeOf(c)) {
+    c = p;
+  }
+
+  Object.setPrototypeOf(c, Component.prototype);
 }


### PR DESCRIPTION
Don't overwrite the current base class but rather add Component as a new base class to the end of the prototype chain. If we overwrite the immediate base, we break ES6 classes and inheritance, especially if used with babel. Babel adds the following check:

```
function _classCallCheck(instance, Constructor) { 
    if (!(instance instanceof Constructor)) { 
        throw new TypeError("Cannot call a class as a function");
    }
}
```

That breaks with the current Derby implementation since Constructor will be changed to Component instead of the original class.
