### PR TITLE
Bundle cleanup (non-production): Correctly clean up app names with dashes

### DIFF
--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -152,8 +152,9 @@ App.prototype.writeScripts = function(backend, dir, options, cb) {
     if (!util.isProduction) {
       var filenames = fs.readdirSync(dir);
       for (var i = 0; i < filenames.length; i++) {
-        var item = filenames[i].split(/[-.]/);
-        if (item[0] === app.name && item[1] !== app.scriptHash) {
+        // Match and extract name, scriptHash, and extension.
+        var fileParts = filenames[i].match(/^(.+)-(\w+)(\..+)?$/);
+        if (fileParts && fileParts[1] === app.name && fileParts[2] !== app.scriptHash) {
           var oldFilename = path.join(dir, filenames[i]);
           fs.unlinkSync(oldFilename);
         }

--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -150,14 +150,22 @@ App.prototype.writeScripts = function(backend, dir, options, cb) {
     // different versions of the app in parallel out of the same directory,
     // such as during a rolling restart.
     if (!util.isProduction) {
+      var appPrefix = app.name + '-';
+      var currentBundlePrefix = appPrefix + app.scriptHash;
       var filenames = fs.readdirSync(dir);
       for (var i = 0; i < filenames.length; i++) {
-        // Match and extract name, scriptHash, and extension.
-        var fileParts = filenames[i].match(/^(.+)-(\w+)(\..+)?$/);
-        if (fileParts && fileParts[1] === app.name && fileParts[2] !== app.scriptHash) {
-          var oldFilename = path.join(dir, filenames[i]);
-          fs.unlinkSync(oldFilename);
+        var filename = filenames[i];
+        if (filename.indexOf(appPrefix) !== 0) {
+          // Not a bundle for this app, skip.
+          continue;
         }
+        if (filename.indexOf(currentBundlePrefix) === 0) {
+          // Current (newly written) bundle for this app, skip.
+          continue;
+        }
+        // Older bundle for this app, clean it up.
+        var oldFilename = path.join(dir, filename);
+        fs.unlinkSync(oldFilename);
       }
     }
     cb && cb();


### PR DESCRIPTION
In development mode, `App#writeScripts` tries to clean up old script bundles for the app being bundled.

However, it currently doesn't correctly handle app names with dashes. The bundles for such apps look like "demo-app-1234abc.js" and "demo-app-1234abc.map.json", which means the `filenames[i].split(/[-.]/)` extracts an app name of "demo" and a script hash of "app".

This switches to checking for matching app name / script hash prefixes with `indexOf`, which correctly matches app names with dashes (and dots).