### PR TITLE
Don't crash the server when there's a parsing error in a template file

### DIFF
--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -262,13 +262,14 @@ App.prototype._watchViews = function(filenames, filename, namespace) {
   var watcher = chokidar.watch(filenames);
   watcher.on('change', function() {
     watcher.close();
+    app.loadViews(filename, namespace);
     try {
-      app.loadViews(filename, namespace);
       app._updateScriptViews();
-      app._refreshClients();
     } catch (e) {
       console.error(e);
+      return;
     }
+    app._refreshClients();
   });
 };
 
@@ -277,13 +278,14 @@ App.prototype._watchStyles = function(filenames, filename, options) {
   var watcher = chokidar.watch(filenames);
   watcher.on('change', function() {
     watcher.close();
+    var styles = app._loadStyles(filename, options);
     try {
-      var styles = app._loadStyles(filename, options);
       app._updateScriptViews();
-      app._refreshStyles(filename, styles);
     } catch (e) {
       console.error(e);
+      return;
     }
+    app._refreshStyles(filename, styles);
   });
 };
 

--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -262,9 +262,13 @@ App.prototype._watchViews = function(filenames, filename, namespace) {
   var watcher = chokidar.watch(filenames);
   watcher.on('change', function() {
     watcher.close();
-    app.loadViews(filename, namespace);
-    app._updateScriptViews();
-    app._refreshClients();
+    try {
+      app.loadViews(filename, namespace);
+      app._updateScriptViews();
+      app._refreshClients();
+    } catch (e) {
+      console.error(e);
+    }
   });
 };
 
@@ -273,9 +277,13 @@ App.prototype._watchStyles = function(filenames, filename, options) {
   var watcher = chokidar.watch(filenames);
   watcher.on('change', function() {
     watcher.close();
-    var styles = app._loadStyles(filename, options);
-    app._updateScriptViews();
-    app._refreshStyles(filename, styles);
+    try {
+      var styles = app._loadStyles(filename, options);
+      app._updateScriptViews();
+      app._refreshStyles(filename, styles);
+    } catch (e) {
+      console.error(e);
+    }
   });
 };
 


### PR DESCRIPTION
There's no need to crash the server in non-production mode when there's a parsing error in a watched template file.

Instead, this logs the error to the console.