### PR TITLE
Run Travis CI for Node v4 and v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
+  - 6
+  - 4
   - 0.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - 6
   - 4
-  - 0.10

--- a/lib/documentListeners.js
+++ b/lib/documentListeners.js
@@ -20,9 +20,9 @@ function inputIsNumberValue(input) {
   var type = input.type;
   return (type === 'number' || (type === 'range' && !input.multiple));
 }
-function inputValue(input) {
+var inputValue = function(input) {
   return inputIsNumberValue(input) ? input.valueAsNumber : input.value;
-}
+};
 
 function addDocumentListeners(doc) {
   doc.addEventListener('input', documentInput, true);


### PR DESCRIPTION
# Why

Addresses: https://github.com/derbyjs/derby/issues/516

> The Travis badge says "build unknown", but it should say "build passing". This would help improve the image of the project, and would make it more appealing for potential adopters.

# Changes

I reactivated Travis for Derby and updated the config to run tests for Node v4 and v6.

The jslint step was failing because 
```
lib/documentListeners.js: line 51, col 5, Reassignment of 'inputValue', which is is a function. Use 'var' or 'let' to declare bindings that may change.
```

So the code change is to fix that linting error.