### PR TITLE
[Work-In-Progress] Add client-side-only rendering mode and update App bundling logic. Rebased.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.swp
 node_modules
+lib/*_views.js

--- a/lib/App.js
+++ b/lib/App.js
@@ -253,6 +253,17 @@ App.prototype._handleMessage = function(action, message) {
       window.location = window.location;
     });
   }
+  function registerClient() {
+    var data = {name: app.name, hash: app.scriptHash};
+    app.model.channel.send('derby:app', data, function(err) {
+      if (!err) return;
+      // Reload in a timeout so that returning fetches have time to complete
+      // in case an onbeforeunload handler is being used
+      setTimeout(function() {
+        window.location = window.location;
+      }, 100);
+    });
+  }
 };
 
 util.serverRequire(module, './App.server');

--- a/lib/App.js
+++ b/lib/App.js
@@ -29,7 +29,10 @@ function App(derby, name, filename, options) {
   this.tracksRoutes = tracks.setup(this);
   this.model = null;
   this.page = null;
-  this._init(options);
+  this.serverRender = (process.env.DERBY_SERVER_RENDER == null) ?
+    util.isProduction
+    : process.env.DERBY_SERVER_RENDER;
+  this._init();
 }
 
 function createAppPage() {

--- a/lib/App.js
+++ b/lib/App.js
@@ -32,7 +32,7 @@ function App(derby, name, filename, options) {
   this.serverRender = (process.env.DERBY_SERVER_RENDER == null) ?
     util.isProduction
     : process.env.DERBY_SERVER_RENDER;
-  this._init();
+  this._init(options);
 }
 
 function createAppPage() {
@@ -248,7 +248,7 @@ App.prototype._handleMessage = function(action, message) {
       message.filename + '"]');
     if (styleElement) styleElement.innerHTML = message.css;
 
-  } else if (action === 'refreshScripts') {
+  } else if (action === 'reload') {
     this.model.whenNothingPending(function() {
       window.location = window.location;
     });

--- a/lib/App.js
+++ b/lib/App.js
@@ -248,7 +248,7 @@ App.prototype._handleMessage = function(action, message) {
       message.filename + '"]');
     if (styleElement) styleElement.innerHTML = message.css;
 
-  } else if (action === 'reload') {
+  } else if (action === 'refreshScripts') {
     this.model.whenNothingPending(function() {
       window.location = window.location;
     });

--- a/lib/App.js
+++ b/lib/App.js
@@ -86,7 +86,11 @@ App.prototype._finishInit = function() {
       console.warn('attachment error', err.stack);
     }
   } else {
-    page.attach();
+    if (this.serverRender) {
+      page.attach();
+    } else {
+      page.render(this.model.get('$render.ns'));
+    }
   }
   this.emit('load', page);
 };

--- a/lib/App.js
+++ b/lib/App.js
@@ -253,17 +253,6 @@ App.prototype._handleMessage = function(action, message) {
       window.location = window.location;
     });
   }
-  function registerClient() {
-    var data = {name: app.name, hash: app.scriptHash};
-    app.model.channel.send('derby:app', data, function(err) {
-      if (!err) return;
-      // Reload in a timeout so that returning fetches have time to complete
-      // in case an onbeforeunload handler is being used
-      setTimeout(function() {
-        window.location = window.location;
-      }, 100);
-    });
-  }
 };
 
 util.serverRequire(module, './App.server');

--- a/lib/App.js
+++ b/lib/App.js
@@ -12,7 +12,7 @@ var util = require('racer/lib/util');
 var derbyTemplates = require('derby-templates');
 var documentListeners = require('./documentListeners');
 var Page = require('./Page');
-var serializedViews = require('./_views');
+var serializedViews;
 
 module.exports = App;
 
@@ -52,6 +52,8 @@ App.prototype._init = function() {
   this._waitForAttach = true;
   this._cancelAttach = false;
   this.model = new this.derby.Model();
+  this.model.createConnection();
+  serializedViews = require('views');
   serializedViews(derbyTemplates, this.views);
   // Must init async so that app.on('model') listeners can be added.
   // Must also wait for content ready so that bundle is fully downloaded.

--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -329,7 +329,7 @@ App.prototype._autoRefresh = function(backend) {
 
   backend.use('receive', function(request, next) {
     var data = request.data;
-    if (data.derby) {
+    if (data.derby && data.name === app.name) {
       return app._handleMessage(request.agent, data.derby, data);
     }
     next();
@@ -338,9 +338,6 @@ App.prototype._autoRefresh = function(backend) {
 
 App.prototype._handleMessage = function(agent, action, message) {
   if (action === 'app') {
-    if (message.name !== this.name) {
-      return;
-    }
     if (message.hash !== this.scriptHash) {
       return agent.send({derby: 'reload'});
     }

--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -32,6 +32,11 @@ App.prototype._init = function(options) {
   this.scriptCrossOrigin = (options && options.scriptCrossOrigin) || false;
   this.scriptUrl = null;
   this.scriptMapUrl = null;
+  this.viewsFilename = path.join(
+    os.tmpdir(),
+    (this.name || Date.now()) +
+     '_views.js'
+  );
   this.agents = null;
   this.styleExtensions = STYLE_EXTENSIONS.slice();
   this.viewExtensions = VIEW_EXTENSIONS.slice();
@@ -75,18 +80,7 @@ App.prototype._init = function(options) {
   this.views.register('Head', '', {serverOnly: true});
   this.views.register('Body', '');
   this.views.register('Tail', '');
-  this._initViewsFile()
 };
-
-App.prototype._initViewsFile = function() {
-  var viewsFilename = path.join(
-    os.tmpdir(),
-    (this.name || Date.now()) +
-     '_views.js'
-  );
-  fs.openSync(viewsFilename, 'w+');
-  this.viewsFilename = fs.realpathSync(viewsFilename);
-}
 
 App.prototype.createPage = function(req, res, next) {
   var model = req.model || new racer.Model();

--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -102,11 +102,12 @@ App.prototype.bundle = function(backend, options, cb) {
   // function that can recreate them in the client
   var viewsSource = this._viewsSource(options);
   var bundleFiles = [];
+  app.viewsFilename = path.join(__dirname, './' + app.name + '_views.js');
+  options.ignore = [app.viewsFilename];
   backend.once('bundle', function(bundle) {
     bundle.require(path.dirname(__dirname), {expose: 'derby'});
-    var viewsFilename = path.join(__dirname, './' + app.name + '_views.js');
-    fs.writeFileSync(viewsFilename, viewsSource);
-    bundle.require(viewsFilename, {expose: 'views'});
+    fs.writeFileSync(app.viewsFilename, viewsSource);
+    bundle.require(app.viewsFilename, {expose: 'views'});
     bundle.on('file', function(filename) {
       bundleFiles.push(filename);
     });
@@ -300,7 +301,10 @@ App.prototype._updateScriptViews = function() {
   i = script.indexOf('/*DERBY_SERIALIZED_VIEWS_END*/');
   var after = script.slice(i + 30);
   var viewsSource = this._viewsSource();
+  // Update the views by injecting the new views into the existing bundle
   fs.writeFileSync(this.scriptFilename, before + viewsSource + after, 'utf8');
+  // Update the actual views file so the next rebundle will pick up the changes
+  fs.writeFileSync(this.viewsFilename, viewsSource);
 };
 
 App.prototype._autoRefresh = function(backend) {

--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -54,6 +54,14 @@ App.prototype._init = function(options) {
     '<view is="{{$render.prefix}}BodyElement"></view>',
     {serverOnly: true}
   );
+  this.views.register('BootstrapPage',
+    '<!DOCTYPE html>' +
+    '<meta charset="utf-8">' +
+    '<title> </title>' +
+    '<view name="{{$render.prefix}}Styles"></view>' +
+    '<view name="{{$render.prefix}}Head"></view>',
+    {serverOnly: true}
+  );
   this.views.register('TitleElement',
     '<title><view is="{{$render.prefix}}Title"></view></title>'
   );

--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -382,6 +382,6 @@ App.prototype._refreshScripts = function(filename) {
   if (!this.clients) return;
   var data = {filename: filename};
   for (var id in this.clients) {
-    this.clients[id].channel.send('derby:refreshScripts', data);
+    this.clients[id].channel.send('derby:reload', data);
   }
 };

--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -152,7 +152,8 @@ App.prototype._writeScripts = function (dir, source, map, options) {
 App.prototype.writeScripts = function(backend, dir, options, cb) {
   var app = this;
   // racer-bundle will call this whenever it rebundles the app
-  options.onRebundle = function(source, map, options) {
+  options.onRebundle = function(err, source, map) {
+    if (err) throw err;
     app._writeScripts(dir, source, map, options);
     app._refreshScripts();
   };

--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -37,6 +37,7 @@ App.prototype._init = function(options) {
   this.viewExtensions = VIEW_EXTENSIONS.slice();
   this.compilers = util.copyObject(COMPILERS);
 
+  this.viewsFilename = path.join(__dirname, './' + this.name + '_views.js');
   this.serializedDir = path.dirname(this.filename || '') + '/derby-serialized';
   this.serializedBase = this.serializedDir + '/' + this.name;
   if (fs.existsSync(this.serializedBase + '.json')) {
@@ -102,7 +103,6 @@ App.prototype.bundle = function(backend, options, cb) {
   // function that can recreate them in the client
   var viewsSource = this._viewsSource(options);
   var bundleFiles = [];
-  app.viewsFilename = path.join(__dirname, './' + app.name + '_views.js');
   options.ignore = [app.viewsFilename];
   backend.once('bundle', function(bundle) {
     bundle.require(path.dirname(__dirname), {expose: 'derby'});
@@ -269,6 +269,17 @@ App.prototype._loadStyles = function(filename, options) {
   }
 
   return styles;
+};
+
+App.prototype._watchBundle = function(filenames) {
+  if (!process.send) return;
+  if (!this.serverRender) return;
+  var app = this;
+  var watcher = chokidar.watch(filenames);
+  watcher.on('change', function() {
+    watcher.close();
+    process.send({type: 'reload'});
+  });
 };
 
 App.prototype._watchViews = function(filenames, filename, namespace) {

--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -8,9 +8,9 @@
 
 var crypto = require('crypto');
 var fs = require('fs');
+var os = require('os');
 var path = require('path');
 var chokidar = require('chokidar');
-var through = require('through');
 var derbyTemplates = require('derby-templates');
 var racer = require('racer');
 var util = racer.util;
@@ -37,7 +37,7 @@ App.prototype._init = function(options) {
   this.viewExtensions = VIEW_EXTENSIONS.slice();
   this.compilers = util.copyObject(COMPILERS);
 
-  this.viewsFilename = path.join(__dirname, './' + this.name + '_views.js');
+  this.viewsFilename = path.join(os.tmpdir(), this.name + '_views.js');
   this.serializedDir = path.dirname(this.filename || '') + '/derby-serialized';
   this.serializedBase = this.serializedDir + '/' + this.name;
   if (fs.existsSync(this.serializedBase + '.json')) {
@@ -103,7 +103,7 @@ App.prototype.bundle = function(backend, options, cb) {
   // function that can recreate them in the client
   var viewsSource = this._viewsSource(options);
   var bundleFiles = [];
-  options.ignore = [app.viewsFilename];
+  options.ignore = [path.join('**', app.viewsFilename)];
   backend.once('bundle', function(bundle) {
     bundle.require(path.dirname(__dirname), {expose: 'derby'});
     fs.writeFileSync(app.viewsFilename, viewsSource);

--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -104,19 +104,9 @@ App.prototype.bundle = function(backend, options, cb) {
   var bundleFiles = [];
   backend.once('bundle', function(bundle) {
     bundle.require(path.dirname(__dirname), {expose: 'derby'});
-    // Hack to inject the views script into the Browserify bundle by replacing
-    // the empty _views.js file with the generated source
-    var viewsFilename = require.resolve('./_views');
-    bundle.transform(function(filename) {
-      if (filename !== viewsFilename) return through();
-      return through(
-        function write() {}
-      , function end() {
-          this.queue(viewsSource);
-          this.queue(null);
-        }
-      );
-    }, {global: true});
+    var viewsFilename = path.join(__dirname, './' + app.name + '_views.js');
+    fs.writeFileSync(viewsFilename, viewsSource);
+    bundle.require(viewsFilename, {expose: 'views'});
     bundle.on('file', function(filename) {
       bundleFiles.push(filename);
     });

--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -293,13 +293,9 @@ App.prototype._watchStyles = function(filenames, filename, options) {
 
 App.prototype._updateScriptViews = function() {
   if (!this.scriptFilename) return;
-  var script = fs.readFileSync(this.scriptFilename, 'utf8');
-  var i = script.indexOf('/*DERBY_SERIALIZED_VIEWS*/');
-  var before = script.slice(0, i);
-  var i = script.indexOf('/*DERBY_SERIALIZED_VIEWS_END*/');
-  var after = script.slice(i + 30);
   var viewsSource = this._viewsSource();
-  fs.writeFileSync(this.scriptFilename, before + viewsSource + after, 'utf8');
+  var viewsFilename = path.join(__dirname, './' + this.name + '_views.js');
+  fs.writeFileSync(viewsFilename, viewsSource);
 };
 
 App.prototype._autoRefresh = function(backend) {

--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -355,3 +355,11 @@ App.prototype._refreshStyles = function(filename, styles) {
     this.agents[id].send(message);
   }
 };
+
+App.prototype._refreshScripts = function(filename) {
+  if (!this.clients) return;
+  var data = {filename: filename};
+  for (var id in this.clients) {
+    this.clients[id].channel.send('derby:refreshScripts', data);
+  }
+};

--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -151,6 +151,11 @@ App.prototype._writeScripts = function (dir, source, map, options) {
 
 App.prototype.writeScripts = function(backend, dir, options, cb) {
   var app = this;
+  // racer-bundle will call this whenever it rebundles the app
+  options.onRebundle = function(source, map, options) {
+    app._writeScripts(dir, source, map, options);
+    app._refreshScripts();
+  };
   this.bundle(backend, options, function(err, source, map) {
     if (err) return cb(err);
     app._writeScripts(dir, source, map, options);

--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -114,9 +114,6 @@ App.prototype.bundle = function(backend, options, cb) {
   });
   backend.bundle(app.filename, options, function(err, source, map) {
     if (err) return cb(err);
-    app.scriptHash = crypto.createHash('md5').update(source).digest('hex');
-    source = source.replace('{{DERBY_SCRIPT_HASH}}', app.scriptHash);
-    source = source.replace(/['"]{{DERBY_BUNDLED_AT}}['"]/, Date.now());
     if (!util.isProduction) {
       app._autoRefresh(backend);
       app._watchBundle(bundleFiles);

--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -277,16 +277,6 @@ App.prototype._watchStyles = function(filenames, filename, options) {
   });
 };
 
-App.prototype._watchBundle = function(filenames) {
-  if (!process.send) return;
-  var app = this;
-  var watcher = chokidar.watch(filenames);
-  watcher.on('change', function() {
-    watcher.close();
-    process.send({type: 'reload'});
-  });
-};
-
 App.prototype._updateScriptViews = function() {
   if (!this.scriptFilename) return;
   var script = fs.readFileSync(this.scriptFilename, 'utf8');

--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -75,7 +75,18 @@ App.prototype._init = function(options) {
   this.views.register('Head', '', {serverOnly: true});
   this.views.register('Body', '');
   this.views.register('Tail', '');
+  this._initViewsFile()
 };
+
+App.prototype._initViewsFile = function() {
+  var viewsFilename = path.join(
+    os.tmpdir(),
+    (this.name || Date.now()) +
+     '_views.js'
+  );
+  fs.openSync(viewsFilename, 'w+');
+  this.viewsFilename = fs.realpathSync(viewsFilename);
+}
 
 App.prototype.createPage = function(req, res, next) {
   var model = req.model || new racer.Model();
@@ -103,7 +114,7 @@ App.prototype.bundle = function(backend, options, cb) {
   // function that can recreate them in the client
   var viewsSource = this._viewsSource(options);
   var bundleFiles = [];
-  options.ignore = [path.join('**', app.viewsFilename)];
+  options.ignore = [app.viewsFilename];
   backend.once('bundle', function(bundle) {
     bundle.require(path.dirname(__dirname), {expose: 'derby'});
     fs.writeFileSync(app.viewsFilename, viewsSource);

--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -293,9 +293,13 @@ App.prototype._watchStyles = function(filenames, filename, options) {
 
 App.prototype._updateScriptViews = function() {
   if (!this.scriptFilename) return;
+  var script = fs.readFileSync(this.scriptFilename, 'utf8');
+  var i = script.indexOf('/*DERBY_SERIALIZED_VIEWS*/');
+  var before = script.slice(0, i);
+  i = script.indexOf('/*DERBY_SERIALIZED_VIEWS_END*/');
+  var after = script.slice(i + 30);
   var viewsSource = this._viewsSource();
-  var viewsFilename = path.join(__dirname, './' + this.name + '_views.js');
-  fs.writeFileSync(viewsFilename, viewsSource);
+  fs.writeFileSync(this.scriptFilename, before + viewsSource + after, 'utf8');
 };
 
 App.prototype._autoRefresh = function(backend) {

--- a/lib/App.server.js
+++ b/lib/App.server.js
@@ -122,26 +122,38 @@ App.prototype.bundle = function(backend, options, cb) {
   });
 };
 
+App.prototype._writeScripts = function (dir, source, map, options) {
+  var app = this;
+
+  // Calculate the script hash
+  app.scriptHash = crypto.createHash('md5').update(source).digest('hex');
+  source = source.replace('{{DERBY_SCRIPT_HASH}}', app.scriptHash);
+  source = source.replace(/['"]{{DERBY_BUNDLED_AT}}['"]/, Date.now());
+
+  // Create the derby dir if it doesn't exist
+  dir = path.join(dir, 'derby');
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir);
+  var filename = app.name + '-' + app.scriptHash;
+  var base = path.join(dir, filename);
+  app.scriptUrl = '/derby/' + filename + '.js';
+
+  // Write current map and bundle files
+  if (!(options && options.disableScriptMap)) {
+    app.scriptMapUrl = app.scriptMapBaseUrl +  '/derby/' + filename + '.map.json';
+    source += '\n//# sourceMappingURL=' + app.scriptMapUrl;
+    app.scriptMapFilename = base + '.map.json';
+    fs.writeFileSync(app.scriptMapFilename, map, 'utf8');
+  }
+  // Write the bundle to disk
+  app.scriptFilename = base + '.js';
+  fs.writeFileSync(app.scriptFilename, source, 'utf8');
+}
+
 App.prototype.writeScripts = function(backend, dir, options, cb) {
   var app = this;
   this.bundle(backend, options, function(err, source, map) {
     if (err) return cb(err);
-    dir = path.join(dir, 'derby');
-    if (!fs.existsSync(dir)) fs.mkdirSync(dir);
-    var filename = app.name + '-' + app.scriptHash;
-    var base = path.join(dir, filename);
-    app.scriptUrl = app.scriptBaseUrl + '/derby/' + filename + '.js';
-
-    // Write current map and bundle files
-    if (!(options && options.disableScriptMap)) {
-      app.scriptMapUrl = app.scriptMapBaseUrl +  '/derby/' + filename + '.map.json';
-      source += '\n//# sourceMappingURL=' + app.scriptMapUrl;
-      app.scriptMapFilename = base + '.map.json';
-      fs.writeFileSync(app.scriptMapFilename, map, 'utf8');
-    }
-    app.scriptFilename = base + '.js';
-    fs.writeFileSync(app.scriptFilename, source, 'utf8');
-
+    app._writeScripts(dir, source, map, options);
     // Delete app bundles with same name in development so files don't
     // accumulate. Don't do this automatically in production, since there could
     // be race conditions with multiple processes intentionally running

--- a/lib/Page.server.js
+++ b/lib/Page.server.js
@@ -19,7 +19,7 @@ Page.prototype.render = function(status, ns) {
   }
 
   this._setRenderParams(ns);
-  var pageHtml = (this.serverRender) ? this.get('Page', ns) : this.get('BootstrapPage', ns);
+  var pageHtml = (this.app.serverRender) ? this.get('Page', ns) : this.get('BootstrapPage', ns);
   var pageHtml = this.get('Page', ns);
   this.res.write(pageHtml);
 

--- a/lib/Page.server.js
+++ b/lib/Page.server.js
@@ -19,6 +19,7 @@ Page.prototype.render = function(status, ns) {
   }
 
   this._setRenderParams(ns);
+  var pageHtml = (this.serverRender) ? this.get('Page', ns) : this.get('BootstrapPage', ns);
   var pageHtml = this.get('Page', ns);
   this.res.write(pageHtml);
 

--- a/lib/Page.server.js
+++ b/lib/Page.server.js
@@ -20,7 +20,6 @@ Page.prototype.render = function(status, ns) {
 
   this._setRenderParams(ns);
   var pageHtml = (this.app.serverRender) ? this.get('Page', ns) : this.get('BootstrapPage', ns);
-  var pageHtml = this.get('Page', ns);
   this.res.write(pageHtml);
 
   var bundleScriptTag = '<script async data-derby-app src="' + this.app.scriptUrl + '"';

--- a/lib/_views.js
+++ b/lib/_views.js
@@ -1,2 +1,0 @@
-// This file is intentionally empty.
-// It's used in browserifying as the placeholder for serialized views.


### PR DESCRIPTION
Work in progress.

Refer to https://github.com/derbyjs/derby/pull/521

This PR attempts to update the above PR with the latest changes in an effort to get hot reloading to work again.

This branch does not work at the moment. Currently, any changes would cause a crash to Derby because it cannot reference certain paths properly.