### PR TITLE
0.10

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -6,11 +6,14 @@
  *
  */
 
+var path = require('path');
 var EventEmitter = require('events').EventEmitter;
 var tracks = require('tracks');
 var util = require('racer/lib/util');
 var derbyTemplates = require('derby-templates');
+var templates = derbyTemplates.templates;
 var documentListeners = require('./documentListeners');
+var components = require('./components');
 var Page = require('./Page');
 var serializedViews = require('./_views');
 
@@ -25,7 +28,7 @@ function App(derby, name, filename, options) {
   this.bundledAt = '{{DERBY_BUNDLED_AT}}';
   this.Page = createAppPage();
   this.proto = this.Page.prototype;
-  this.views = new derbyTemplates.templates.Views();
+  this.views = new templates.Views();
   this.tracksRoutes = tracks.setup(this);
   this.model = null;
   this.page = null;
@@ -172,6 +175,43 @@ App.prototype.serverUse = util.serverUse;
 App.prototype.loadViews = function() {};
 
 App.prototype.loadStyles = function() {};
+
+App.prototype.component = function(viewName, constructor) {
+  if (typeof viewName === 'function') {
+    constructor = viewName;
+    viewName = null;
+  }
+
+  // Inherit from Component
+  components.extendComponent(constructor);
+
+  // Load template view from filename
+  if (constructor.prototype.view) {
+    var viewFilename = constructor.prototype.view;
+    viewName = constructor.prototype.name || path.basename(viewFilename, '.html');
+    this.loadViews(viewFilename, viewName);
+
+  } else if (!viewName) {
+    if (constructor.prototype.name) {
+      viewName = constructor.prototype.name;
+      var view = this.views.register(viewName);
+      view.template = templates.emptyTemplate;
+    } else {
+      throw new Error('No view name specified for component');
+    }
+  }
+
+  // Associate the appropriate view with the component type
+  var view = this.views.find(viewName);
+  if (!view) {
+    var message = this.views.findErrorMessage(viewName);
+    throw new Error(message);
+  }
+  view.componentFactory = components.createFactory(constructor);
+
+  // Make chainable
+  return this;
+};
 
 App.prototype.createPage = function() {
   if (this.page) {

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -274,12 +274,15 @@ BindingWrapper.prototype.update = function(previous, pass) {
 };
 BindingWrapper.prototype.insert = function(index, howMany) {
   this.binding.insert(index, howMany);
+  this.updateDependencies();
 };
 BindingWrapper.prototype.remove = function(index, howMany) {
   this.binding.remove(index, howMany);
+  this.updateDependencies();
 };
 BindingWrapper.prototype.move = function(from, to, howMany) {
   this.binding.move(from, to, howMany);
+  this.updateDependencies();
 };
 
 function equalDependencies(a, b) {

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -2,7 +2,9 @@ var derbyTemplates = require('derby-templates');
 var contexts = derbyTemplates.contexts;
 var expressions = derbyTemplates.expressions;
 var templates = derbyTemplates.templates;
+var DependencyOptions = derbyTemplates.options.DependencyOptions;
 var util = require('racer/lib/util');
+var components = require('./components');
 var EventModel = require('./eventmodel');
 var textDiff = require('./textDiff');
 var Controller = require('./Controller');
@@ -233,6 +235,12 @@ function BindingWrapper(eventModel, expression, binding) {
   this.id = nextId++;
   this.eventModels = null;
   this.dependencies = null;
+  this.ignoreTemplateDependency = (
+    binding instanceof components.ComponentAttributeBinding
+  ) || (
+    (binding.template instanceof templates.DynamicText) &&
+    (binding instanceof templates.RangeBinding)
+  );
   if (binding.meta) {
     binding.meta.push(this);
   } else {
@@ -240,7 +248,12 @@ function BindingWrapper(eventModel, expression, binding) {
   }
 }
 BindingWrapper.prototype.updateDependencies = function() {
-  var dependencies = this.expression.dependencies(this.binding.context);
+  var dependencyOptions;
+  if (this.ignoreTemplateDependency && this.binding.condition instanceof templates.Template) {
+    dependencyOptions = new DependencyOptions();
+    dependencyOptions.ignoreTemplate = this.binding.condition;
+  }
+  var dependencies = this.expression.dependencies(this.binding.context, dependencyOptions);
   if (this.dependencies) {
     // Do nothing if dependencies haven't changed
     if (equalDependencies(this.dependencies, dependencies)) return;

--- a/lib/components.js
+++ b/lib/components.js
@@ -7,18 +7,17 @@
  *
  */
 
-var path = require('path');
 var util = require('racer/lib/util');
 var derbyTemplates = require('derby-templates');
 var templates = derbyTemplates.templates;
 var expressions = derbyTemplates.expressions;
-var App = require('./App');
 var Controller = require('./Controller');
 
 exports.Component = Component;
 exports.ComponentFactory = ComponentFactory;
 exports.SingletonComponentFactory = SingletonComponentFactory;
 exports.createFactory = createFactory;
+exports.extendComponent = extendComponent;
 
 function Component(parent, context, id, scope) {
   this.parent = parent;
@@ -210,43 +209,6 @@ SingletonComponentFactory.prototype.init = function(context) {
 };
 // Don't call the create method for singleton components
 SingletonComponentFactory.prototype.create = function() {};
-
-App.prototype.component = function(viewName, constructor) {
-  if (typeof viewName === 'function') {
-    constructor = viewName;
-    viewName = null;
-  }
-
-  // Inherit from Component
-  extendComponent(constructor);
-
-  // Load template view from filename
-  if (constructor.prototype.view) {
-    var viewFilename = constructor.prototype.view;
-    viewName = constructor.prototype.name || path.basename(viewFilename, '.html');
-    this.loadViews(viewFilename, viewName);
-
-  } else if (!viewName) {
-    if (constructor.prototype.name) {
-      viewName = constructor.prototype.name;
-      var view = this.views.register(viewName);
-      view.template = templates.emptyTemplate;
-    } else {
-      throw new Error('No view name specified for component');
-    }
-  }
-
-  // Associate the appropriate view with the component type
-  var view = this.views.find(viewName);
-  if (!view) {
-    var message = this.views.findErrorMessage(viewName);
-    throw new Error(message);
-  }
-  view.componentFactory = createFactory(constructor);
-
-  // Make chainable
-  return this;
-};
 
 function extendComponent(constructor) {
   // Don't do anything if the constructor already extends Component

--- a/lib/components.js
+++ b/lib/components.js
@@ -96,7 +96,7 @@ function emitInitHooks(context, component) {
   }
 }
 
-function setAttributes(context, model) {
+function setModelAttributes(context, model) {
   if (!context.attributes) return;
   // Set attribute values on component model
   for (var key in context.attributes) {
@@ -132,7 +132,7 @@ ComponentFactory.prototype.init = function(context) {
   var model = parent.model.root.eventContext(component);
   model._at = scope.join('.');
   model.set('id', id);
-  setAttributes(context, model);
+  setModelAttributes(context, model);
   // Store a reference to the component's scope such that the expression
   // getters are relative to the component
   model.data = model.get();

--- a/lib/components.js
+++ b/lib/components.js
@@ -58,6 +58,9 @@ Component.prototype.getAttribute = function(key) {
   var attributeContext = this.context.forAttribute(key);
   if (!attributeContext) return;
   var value = attributeContext.attributes[key];
+  if (value instanceof expressions.Expression) {
+    return value.get(attributeContext);
+  }
   return value && expressions.renderValue(value, attributeContext);
 };
 

--- a/lib/components.js
+++ b/lib/components.js
@@ -14,6 +14,8 @@ var expressions = derbyTemplates.expressions;
 var Controller = require('./Controller');
 
 exports.Component = Component;
+exports.ComponentAttribute = ComponentAttribute;
+exports.ComponentAttributeBinding = ComponentAttributeBinding;
 exports.ComponentFactory = ComponentFactory;
 exports.SingletonComponentFactory = SingletonComponentFactory;
 exports.createFactory = createFactory;
@@ -105,11 +107,13 @@ function ComponentAttribute(expression, model, key) {
 }
 ComponentAttribute.prototype.update = function(context, binding) {
   var value = this.expression.get(context);
+  binding.condition = value;
   this.model.setDiff(this.key, value);
 };
 function ComponentAttributeBinding(expression, model, key, context) {
   this.template = new ComponentAttribute(expression, model, key);
   this.context = context;
+  this.condition = expression.get(context);
 }
 ComponentAttributeBinding.prototype = Object.create(templates.Binding.prototype);
 ComponentAttributeBinding.prototype.constructor = ComponentAttributeBinding;
@@ -136,7 +140,7 @@ function setModelAttribute(context, model, key, value) {
     } else {
       var binding = new ComponentAttributeBinding(value, model, key, context);
       context.addBinding(binding);
-      binding.update();
+      model.set(key, binding.condition);
     }
     return;
   }

--- a/lib/components.js
+++ b/lib/components.js
@@ -96,22 +96,70 @@ function emitInitHooks(context, component) {
   }
 }
 
+function ComponentAttribute(expression, model, key) {
+  this.expression = expression;
+  this.model = model;
+  this.key = key;
+}
+ComponentAttribute.prototype.update = function(context, binding) {
+  var value = this.expression.get(context);
+  this.model.setDiff(this.key, value);
+};
+function ComponentAttributeBinding(expression, model, key, context) {
+  this.template = new ComponentAttribute(expression, model, key);
+  this.context = context;
+}
+ComponentAttributeBinding.prototype = Object.create(templates.Binding.prototype);
+ComponentAttributeBinding.prototype.constructor = ComponentAttributeBinding;
+
 function setModelAttributes(context, model) {
   if (!context.attributes) return;
   // Set attribute values on component model
   for (var key in context.attributes) {
-    var attribute = context.attributes[key];
-    var segments = (
-      attribute instanceof templates.ParentWrapper &&
-      attribute.expression &&
-      attribute.expression.pathSegments(context)
-    );
+    var value = context.attributes[key];
+    setModelAttribute(context, model, key, value);
+  }
+}
+
+function setModelAttribute(context, model, key, value) {
+  // If an attribute is an Expression, set its current value in the model
+  // and keep it up to date. When it is a resolvable path, use a Racer ref,
+  // which makes it a two-way binding. Otherwise, set to the current value
+  // and create a binding that will set the value in the model as the
+  // expression's dependencies change.
+  if (value instanceof expressions.Expression) {
+    var segments = value.pathSegments(context);
     if (segments) {
       model.root.ref(model._at + '.' + key, segments.join('.'), {updateIndices: true});
     } else {
-      model.set(key, attribute);
+      var binding = new ComponentAttributeBinding(value, model, key, context);
+      context.addBinding(binding);
+      binding.update();
     }
+    return;
   }
+
+  // If an attribute is a Template, set a template object in the model.
+  // Eagerly rendering a template can cause excessive rendering when the
+  // developer wants to pass in a complex chunk of HTML, and if we were to
+  // set a string in the model that represents the template value, we'd lose
+  // the ability to use the value in the component's template, since HTML
+  // would be escaped and we'd lose the ability to create proper bindings.
+  //
+  // This may be of surprise to developers, since it may not be intuitive
+  // whether a passed in value will produce an expression or a template. To
+  // get the rendered value consistently, the component's getAttribute(key)
+  // method may be used to get the value that would be rendered.
+  if (value instanceof templates.Template) {
+    var templateClosure = new templates.TemplateClosure(value, context);
+    model.set(key, templateClosure);
+    return;
+  }
+
+  // For all other value types, set the passed in value directly. Passed in
+  // values will only be set initially, so model paths should be used if
+  // bindings are desired.
+  model.set(key, value);
 }
 
 function createFactory(constructor) {

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
     "tracks": "^0.5.0"
   },
   "devDependencies": {
+    "browserify": "^16.2.2",
     "expect.js": "^0.3.1",
     "express": "^4.13.3",
-    "jshint": "^2.8.0",
-    "mocha": "^2.3.3",
-    "browserify": "^11.2.0"
+    "jshint": "^2.9.5",
+    "mocha": "^5.2.0"
   },
   "optionalDependencies": {},
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "chokidar": "^1.2.0",
-    "derby-parsing": "^0.6.0",
-    "derby-templates": "^0.5.0",
+    "derby-parsing": "^0.7.0",
+    "derby-templates": "^0.6.0",
     "html-util": "^0.2.1",
     "racer": "^0.9.0",
     "resolve": "^1.1.6",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "chokidar": "^1.2.0",
-    "derby-parsing": "^0.5.0",
-    "derby-templates": "^0.4.0",
+    "derby-parsing": "^0.6.0",
+    "derby-templates": "^0.5.0",
     "html-util": "^0.2.1",
     "racer": "^0.9.0",
     "resolve": "^1.1.6",

--- a/test/browser/components.js
+++ b/test/browser/components.js
@@ -1,0 +1,235 @@
+var util = require('./util');
+var derby = util.derby;
+var expectHtml = util.expectHtml;
+
+describe('components', function() {
+
+  describe('attribute to model binding', function() {
+    it('updates model when path attribute changes', function() {
+      this.app = derby.createApp();
+      this.page = this.app.createPage();
+      this.page.model.set('_page.color', 'blue');
+      this.app.views.register('Body',
+        '<view is="swatch" value="{{_page.color}}"></view>'
+      );
+      this.app.views.register('swatch',
+        '<div style="background-color: {{value}}"></div>'
+      );
+      function Swatch() {}
+      this.Swatch = Swatch;
+      this.app.component('swatch', Swatch);
+      var fragment = this.page.getFragment('Body');
+      expectHtml(fragment, '<div style="background-color: blue"></div>');
+      this.page.model.set('_page.color', 'gray');
+      expectHtml(fragment, '<div style="background-color: gray"></div>');
+    });
+
+    it('updates model when expression attribute changes', function() {
+      this.app = derby.createApp();
+      this.page = this.app.createPage();
+      this.page.model.set('_page.color', 'blue');
+      this.app.proto.concat = function() {
+        return Array.prototype.join.call(arguments, '');
+      };
+      this.app.views.register('Body',
+        '<view is="swatch" value="{{concat(\'light\', _page.color)}}"></view>'
+      );
+      this.app.views.register('swatch',
+        '{{@value}}<view is="color" value={{value}} />'
+      );
+      this.app.views.register('color',
+        '<div style="background-color: {{value}}"></div>'
+      );
+      function Swatch() {}
+      this.Swatch = Swatch;
+      this.app.component('swatch', Swatch);
+      var fragment = this.page.getFragment('Body');
+      expectHtml(fragment, 'lightblue<div style="background-color: lightblue"></div>');
+      this.page.model.set('_page.color', 'gray');
+      expectHtml(fragment, 'lightgray<div style="background-color: lightgray"></div>');
+    });
+
+    it('updates model when template attribute changes', function() {
+      this.app = derby.createApp();
+      this.page = this.app.createPage();
+      this.page.model.set('_page.color', 'blue');
+      this.app.proto.concat = function() {
+        return Array.prototype.join.call(arguments, '');
+      };
+      this.app.views.register('Body',
+        '<view is="swatch" value="light{{_page.color}}"></view>'
+      );
+      this.app.views.register('swatch',
+        '<view is="color" value=sd{{value}} />'
+      );
+      this.app.views.register('color',
+        '{{value}}<div style="background-color: {{value}}"></div>'
+      );
+      function Swatch() {}
+      this.Swatch = Swatch;
+      this.app.component('swatch', Swatch);
+      var fragment = this.page.getFragment('Body');
+      expectHtml(fragment, 'lightblue<div style="background-color: lightblue"></div>');
+      this.page.model.set('_page.color', 'gray');
+      expectHtml(fragment, 'lightgray<div style="background-color: lightgray"></div>');
+    });
+
+    it('updates view expression', function() {
+      this.app = derby.createApp();
+      this.page = this.app.createPage();
+      this.page.model.set('_page.color', 'blue');
+      this.page.model.set('_page.view', 'back');
+      this.app.proto.concat = function() {
+        return Array.prototype.join.call(arguments, '');
+      };
+      this.app.views.register('Body',
+        '<view is="swatch" value="{{view _page.view, {value: _page.color}}}"></view>'
+      );
+      this.app.views.register('swatch',
+        '<div style="{{value}}">{{value}}</div>'
+      );
+      this.app.views.register('back',
+        'background-color: light{{@value}}'
+      );
+      this.app.views.register('fore',
+        'color: light{{@value}}'
+      );
+      function Swatch() {}
+      this.Swatch = Swatch;
+      this.app.component('swatch', Swatch);
+      var fragment = this.page.getFragment('Body');
+      expectHtml(fragment, '<div style="background-color: lightblue">background-color: lightblue</div>');
+      this.page.model.set('_page.color', 'gray');
+      expectHtml(fragment, '<div style="background-color: lightgray">background-color: lightgray</div>');
+      this.page.model.set('_page.view', 'fore');
+      expectHtml(fragment, '<div style="color: lightgray">color: lightgray</div>');
+    });
+
+    it('updates model when template attribute changes 2', function() {
+      this.app = derby.createApp();
+      this.page = this.app.createPage();
+      this.page.model.set('_page.color', 'blue');
+      this.app.proto.concat = function() {
+        return Array.prototype.join.call(arguments, '');
+      };
+      this.app.views.register('Body',
+        '<view is="swatch" value="light{{_page.color}}"></view>'
+      );
+      this.app.views.register('swatch',
+        '<div style="background-color: {{value}}">{{value}}</div>'
+      );
+      function Swatch() {}
+      this.Swatch = Swatch;
+      this.app.component('swatch', Swatch);
+      var fragment = this.page.getFragment('Body');
+      expectHtml(fragment, '<div style="background-color: lightblue">lightblue</div>');
+      var previous = this.page.model.set('$components._1.value', 'gray');
+      expectHtml(fragment, '<div style="background-color: gray">gray</div>');
+      expect(this.page.model.get('_page.color')).equal('blue');
+      this.page.model.set('$components._1.value', previous);
+      expectHtml(fragment, '<div style="background-color: lightblue">lightblue</div>');
+      var previous = this.page.model.set('$components._1.value', 'gray');
+      expectHtml(fragment, '<div style="background-color: gray">gray</div>');
+    });
+
+  });
+
+  describe('rendering', function() {
+    beforeEach(function() {
+    this.app = derby.createApp();
+    this.page = this.app.createPage();
+    this.page.model.set('_page.title', 'Good day');
+    this.app.views.register('Body',
+      '<view is="box" role="container" title="{{_page.title}}">' +
+        '<view is="box" role="inner1" title="Greeting">Hello.</view>' +
+        '<view is="box" role="inner2"></view>' +
+      '</view>'
+    );
+    this.app.views.register('box',
+      '<div class="box">' +
+        '<view is="box-title" tip="{{@title}}">{{@title}}</view>' +
+        '{{@content}}' +
+      '</div>'
+    );
+    this.app.views.register('box-title',
+      '<b title="{{@tip}}">{{@content}}</b>'
+    );
+    function Box() {}
+    this.Box = Box;
+    this.app.component('box', this.Box);
+    function BoxTitle() {}
+    this.BoxTitle = BoxTitle;
+    this.app.component('box-title', this.BoxTitle);
+  });
+
+  it('renders a component', function() {
+    var html = this.page.get('Body');
+    expect(html).equal(
+      '<div class="box">' +
+        '<b title="Good day">Good day</b>' +
+        '<div class="box"><b title="Greeting">Greeting</b>Hello.</div>' +
+        '<div class="box"><b></b></div>' +
+      '</div>'
+    );
+  });
+
+  it('sets attributes as values on component model', function() {
+    var tests = {
+      container: function(box, boxTitle) {
+        expect(box.model.get('title')).equal('Good day');
+        expect(boxTitle.model.get('tip')).equal('Good day');
+        expect(boxTitle.model.get('content')).equal('Good day');
+      },
+      inner1: function(box, boxTitle) {
+        expect(box.model.get('title')).equal('Greeting');
+        expect(box.model.get('content')).equal('Hello.');
+        expect(boxTitle.model.get('tip')).equal('Greeting');
+        expect(boxTitle.model.get('content')).equal('Greeting');
+      },
+      inner2: function(box, boxTitle) {
+        expect(box.model.get('title')).equal(undefined);
+        expect(box.model.get('content')).equal(undefined);
+        expect(boxTitle.model.get('tip')).equal(undefined);
+        expect(boxTitle.model.get('content')).equal(undefined);
+      }
+    };
+    testInit.call(this, tests);
+  });
+
+  it('Component::getAttribute returns passed in values', function() {
+    var tests = {
+      container: function(box, boxTitle) {
+        expect(box.getAttribute('title')).equal('Good day');
+        expect(boxTitle.getAttribute('tip')).equal('Good day');
+        expect(boxTitle.getAttribute('content')).equal('Good day');
+      },
+      inner1: function(box, boxTitle) {
+        expect(box.getAttribute('title')).equal('Greeting');
+        expect(box.getAttribute('content')).equal('Hello.');
+        expect(boxTitle.getAttribute('tip')).equal('Greeting');
+        expect(boxTitle.getAttribute('content')).equal('Greeting');
+      },
+      inner2: function(box, boxTitle) {
+        expect(box.getAttribute('title')).equal(undefined);
+        expect(box.getAttribute('content')).equal(undefined);
+        expect(boxTitle.getAttribute('tip')).equal(undefined);
+        expect(boxTitle.getAttribute('content')).equal(undefined);
+      }
+    };
+    testInit.call(this, tests);
+  });
+
+  function testInit(tests) {
+    this.BoxTitle.prototype.init = function() {
+      var box = this.parent;
+      var boxTitle = this;
+      var role = box.model.get('role');
+      tests[role](box, boxTitle);
+      delete tests[role];
+    }
+    this.page.getFragment('Body');
+    expect(Object.keys(tests).length).equal(0);
+  }
+  });
+
+});


### PR DESCRIPTION
This includes a number of changes that substantially improve Derby's bindings & fixes a key issue in rendering a Template object within text content that could in certain situations not properly escape values rendered in HTML.

This should be generally compatible with earlier versions of Derby, and for the most part, bindings should more intuitively update in a large number of cases where they previously would not have reacted to changes. Many new tests were added to derby-parsing and many bugs were fixed.

Of particular interest is that when instantiating a component, an expression should not update its value in the component's model, regardless of the type of expression. As before, passing in a path expression will use Racer's 'ref' functionality in order to establish a two-way binding. In addition, expressions that cannot be represented by a simple ref, such a function or operator will now update the component's model value whenever the dependencies to the expression change.

As before, Templates are not rendered when instantiating a component. Rather, they are set on the model as a Template value. Then, if the template is used in a view, the template will be rendered as appropriate. This has been improved to work more consistently with array attributes as well.

Based on some simple testing with Lever's complex application, performance impact of these changes is not expected to be significant. No significant difference in rendering times or memory use was found when rendering a sequence of page transitions and actions.