### PR TITLE
use dependencyOptions.setIgnoreTemplate()

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -251,7 +251,7 @@ BindingWrapper.prototype.updateDependencies = function() {
   var dependencyOptions;
   if (this.ignoreTemplateDependency && this.binding.condition instanceof templates.Template) {
     dependencyOptions = new DependencyOptions();
-    dependencyOptions.ignoreTemplate = this.binding.condition;
+    dependencyOptions.setIgnoreTemplate(this.binding.condition);
   }
   var dependencies = this.expression.dependencies(this.binding.context, dependencyOptions);
   if (this.dependencies) {


### PR DESCRIPTION
Use dependencyOptions.setIgnoreTemplate() method in order to ignore ContextClosures, which were preventing us from detecting the templates to ignore. This requires https://github.com/derbyjs/derby-templates/pull/20