### PR TITLE
Switch to immediate model listeners

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -186,10 +186,10 @@ Page.prototype._addModelListenersImmediate = function(eventModel) {
   if (!model) return;
 
   var changeListener = model.on('changeImmediate', function onChange(segments, eventArgs) {
+    // eventArgs[0] is the new value, which Derby bindings don't use directly.
+    var previous = eventArgs[1];
     // The pass parameter is passed in for special handling of updates
     // resulting from stringInsert or stringRemove
-    var value = eventArgs[0];
-    var previous = eventArgs[1];
     var pass = eventArgs[2];
     eventModel.set(segments, previous, pass);
   });

--- a/lib/Page.js
+++ b/lib/Page.js
@@ -135,6 +135,15 @@ Page.prototype._addModelListeners = function(eventModel) {
   var model = this.model;
   if (!model) return;
 
+  if (model.get('$derbyFlags.immediateModelListeners')) {
+    // Registering model listeners with the *Immediate events helps to prevent
+    // a bug with binding updates where a model listener causes a change to the
+    // path being listened on, directly or indirectly. This flag will go away
+    // after a month or so of private testing, and if everything looks fine,
+    // we'll switch unconditionally to *Immediate listeners.
+    return this._addModelListenersImmediate(eventModel);
+  }
+
   var context = this.context;
   var changeListener = model.on('change', '**', function onChange(path, value, previous, pass) {
     var segments = util.castSegments(path.split('.'));
@@ -170,6 +179,50 @@ Page.prototype._addModelListeners = function(eventModel) {
     model.removeListener('insert', insertListener);
     model.removeListener('remove', removeListener);
     model.removeListener('move', moveListener);
+  };
+}
+Page.prototype._addModelListenersImmediate = function(eventModel) {
+  var model = this.model;
+  if (!model) return;
+
+  var changeListener = model.on('changeImmediate', function onChange(segments, eventArgs) {
+    // The pass parameter is passed in for special handling of updates
+    // resulting from stringInsert or stringRemove
+    var value = eventArgs[0];
+    var previous = eventArgs[1];
+    var pass = eventArgs[2];
+    eventModel.set(segments, previous, pass);
+  });
+  var loadListener = model.on('loadImmediate', function onLoad(segments) {
+    eventModel.set(segments);
+  });
+  var unloadListener = model.on('unloadImmediate', function onUnload(segments) {
+    eventModel.set(segments);
+  });
+  var insertListener = model.on('insertImmediate', function onInsert(segments, eventArgs) {
+    var index = eventArgs[0];
+    var values = eventArgs[1];
+    eventModel.insert(segments, index, values.length);
+  });
+  var removeListener = model.on('removeImmediate', function onRemove(segments, eventArgs) {
+    var index = eventArgs[0];
+    var values = eventArgs[1];
+    eventModel.remove(segments, index, values.length);
+  });
+  var moveListener = model.on('moveImmediate', function onMove(segments, eventArgs) {
+    var from = eventArgs[0];
+    var to = eventArgs[1];
+    var howMany = eventArgs[2];
+    eventModel.move(segments, from, to, howMany);
+  });
+
+  this._removeModelListeners = function() {
+    model.removeListener('changeImmediate', changeListener);
+    model.removeListener('loadImmediate', loadListener);
+    model.removeListener('unloadImmediate', unloadListener);
+    model.removeListener('insertImmediate', insertListener);
+    model.removeListener('removeImmediate', removeListener);
+    model.removeListener('moveImmediate', moveListener);
   };
 };
 


### PR DESCRIPTION
This fixes a bug in binding updates, triggered when a model listener causes a change to the path being listened on.

See the new test for more details.

Preliminary app testing all seems fine, but to be safe, I'm putting this behind a flag. To enable the new behavior, do a `model.set('$derbyFlags.immediateModelListeners', true)` before calling `app.createPage()`.

I intend to remove the flag in a month or so, after we do some more internal testing with the flag on.