### PR TITLE
Fix binding update regression with immediateModelListeners flag on

### DIFF
--- a/lib/Page.js
+++ b/lib/Page.js
@@ -185,34 +185,43 @@ Page.prototype._addModelListenersImmediate = function(eventModel) {
   var model = this.model;
   if (!model) return;
 
+  // `util.castSegments(segments)` is needed to cast string segments into
+  // numbers, since EventModel#child does typeof checks against segments. This
+  // could be done once in Racer's Model#emit, instead of in every listener.
   var changeListener = model.on('changeImmediate', function onChange(segments, eventArgs) {
     // eventArgs[0] is the new value, which Derby bindings don't use directly.
     var previous = eventArgs[1];
     // The pass parameter is passed in for special handling of updates
     // resulting from stringInsert or stringRemove
     var pass = eventArgs[2];
+    segments = util.castSegments(segments.slice());
     eventModel.set(segments, previous, pass);
   });
   var loadListener = model.on('loadImmediate', function onLoad(segments) {
+    segments = util.castSegments(segments.slice());
     eventModel.set(segments);
   });
   var unloadListener = model.on('unloadImmediate', function onUnload(segments) {
+    segments = util.castSegments(segments.slice());
     eventModel.set(segments);
   });
   var insertListener = model.on('insertImmediate', function onInsert(segments, eventArgs) {
     var index = eventArgs[0];
     var values = eventArgs[1];
+    segments = util.castSegments(segments.slice());
     eventModel.insert(segments, index, values.length);
   });
   var removeListener = model.on('removeImmediate', function onRemove(segments, eventArgs) {
     var index = eventArgs[0];
     var values = eventArgs[1];
+    segments = util.castSegments(segments.slice());
     eventModel.remove(segments, index, values.length);
   });
   var moveListener = model.on('moveImmediate', function onMove(segments, eventArgs) {
     var from = eventArgs[0];
     var to = eventArgs[1];
     var howMany = eventArgs[2];
+    segments = util.castSegments(segments.slice());
     eventModel.move(segments, from, to, howMany);
   });
 

--- a/test/browser/bindings.mocha.js
+++ b/test/browser/bindings.mocha.js
@@ -432,4 +432,33 @@ describe('bindings', function() {
     $items.insert(0, 'B');
     expectHtml(fragment, '<ul><li>C</li><li>B</li><li>A</li></ul>');
   });
+
+  it('mutation with number path segments', function() {
+    // The Page sets up model listeners that call into event model listeners,
+    // which handle binding updates. The event model expects that any numeric
+    // path segments it receives have been cast into JS numbers, which the
+    // Racer model doesn't necessarily guarantee.
+    var app = derby.createApp();
+    app.views.register('Body',
+      '<ul>' +
+        '{{each _data.items as #item}}' +
+          '<li>{{#item.label}}</li>' +
+        '{{/each}}' +
+      '</ul>'
+    );
+    app.model.set('$derbyFlags.immediateModelListeners', true);
+    var page = app.createPage();
+    var $items = page.model.at('_data.items');
+    $items.set([
+      {label: 'Red', hexCode: '#ff0000'},
+      {label: 'Green', hexCode: '#00ff00'},
+      {label: 'Blue', hexCode: '#0000ff'},
+    ]);
+
+    var fragment = page.getFragment('Body');
+    expectHtml(fragment, '<ul><li>Red</li><li>Green</li><li>Blue</li></ul>');
+    // Test mutation with a numeric path segment.
+    app.model.set('_data.items.1.label', 'Verde');
+    expectHtml(fragment, '<ul><li>Red</li><li>Verde</li><li>Blue</li></ul>');
+  });
 });


### PR DESCRIPTION
During integration testing of the original implementation of `immediateModelListeners` in https://github.com/derbyjs/derby/pull/554, we discovered a couple feature regressions relating to binding updates. Good thing I decided to put it behind an opt-in flag!

The regressions turned out to both be manifestations of the same issue - a mutation on a path with a numeric segment wasn't updating bindings. `EventModel#update` checks `typeof` for path segments, and the implementation of immediate model listeners wasn't calling `castSegments` to convert numeric string segments into JS numbers.

This PR fixes the issue by using `castSegments` like the current non-immediate listeners do, and I've adds a new test for the case of binding updates with numeric segments.

Side note - `immediateModelListeners` also gets us some significant client render perf improvements when using large reactive functions. I edited the original PR https://github.com/derbyjs/derby/pull/554 with details.