### PR TITLE
Component::bind(), throttle(), debounce(), and debounceAsync()

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -181,7 +181,7 @@ Component.prototype.debounce = function(callback, delay) {
 // Like component.bind(), will no longer call back once the component is
 // destroyed, which avoids possible bugs and memory leaks.
 Component.prototype.debounceAsync = function(callback, delay) {
-  var applyArguments = callback.length > 1;
+  var applyArguments = callback.length !== 1;
   delay = delay || 0;
   if (typeof delay !== 'number') {
     throw new Error('Second argument must be a number');

--- a/lib/components.js
+++ b/lib/components.js
@@ -102,7 +102,7 @@ Component.prototype.throttle = function(callback, delayArg) {
       nextArgs = slice.call(arguments);
       if (queueCall) {
         var now = +new Date();
-        var remaining = Math.max(previous - now + delay, 0);
+        var remaining = Math.max(previous + delay - now, 0);
         setTimeout(boundCallback, remaining);
       }
     };

--- a/lib/components.js
+++ b/lib/components.js
@@ -12,6 +12,7 @@ var derbyTemplates = require('derby-templates');
 var templates = derbyTemplates.templates;
 var expressions = derbyTemplates.expressions;
 var Controller = require('./Controller');
+var slice = [].slice;
 
 exports.Component = Component;
 exports.ComponentAttribute = ComponentAttribute;
@@ -37,6 +38,183 @@ Component.prototype.destroy = function() {
   delete this.page._components[this.id];
   var components = this.page._eventModel.object.$components;
   if (components) delete components.object[this.id];
+};
+
+// Apply calls to the passed in function with the component as the context.
+// Stop calling back once the component is destroyed, which avoids possible bugs
+// and memory leaks.
+Component.prototype.bind = function(callback) {
+  var component = this;
+  this.on('destroy', function() {
+    // Reduce potential for memory leaks by removing references to the component
+    // and the passed in callback, which could have closure references
+    component = null;
+    // Cease calling back after component is removed from the DOM
+    callback = null;
+  });
+  return function componentBindWrapper() {
+    if (!callback) return;
+    return callback.apply(component, arguments);
+  };
+};
+
+// When passing in a numeric delay, calls the function at most once per that
+// many milliseconds. Like Underscore, the function will be called on the
+// leading and the trailing edge of the delay as appropriate. Unlike Underscore,
+// calls are consistently called via setTimeout and are never synchronous. This
+// should be used for reducing the frequency of ongoing updates, such as scroll
+// events or other continuous streams of events.
+//
+// Additionally, implements an interface intended to be used with
+// window.requestAnimationFrame or process.nextTick. If one of these is passed,
+// it will be used to create a single async call following any number of
+// synchronous calls. This mode is typically used to coalesce many synchronous
+// events (such as mulitple model events) into a single async event.
+//
+// Like component.bind(), will no longer call back once the component is
+// destroyed, which avoids possible bugs and memory leaks.
+Component.prototype.throttle = function(callback, delayArg) {
+  var component = this;
+  this.on('destroy', function() {
+    // Reduce potential for memory leaks by removing references to the component
+    // and the passed in callback, which could have closure references
+    component = null;
+    // Cease calling back after component is removed from the DOM
+    callback = null;
+  });
+
+  // throttle(callback)
+  // throttle(callback, 150)
+  if (delayArg == null || typeof delayArg === 'number') {
+    var delay = delayArg || 0;
+    var nextArgs;
+    var previous;
+    var boundCallback = function() {
+      var args = nextArgs;
+      nextArgs = null;
+      previous = +new Date();
+      if (callback && args) {
+        callback.apply(component, args);
+      }
+    };
+    return function componentThrottleWrapper() {
+      var queueCall = !nextArgs;
+      nextArgs = slice.call(arguments);
+      if (queueCall) {
+        var now = +new Date();
+        var remaining = Math.max(previous - now + delay, 0);
+        setTimeout(boundCallback, remaining);
+      }
+    };
+  }
+
+  // throttle(callback, window.requestAnimationFrame)
+  // throttle(callback, process.nextTick)
+  if (typeof delayArg === 'function') {
+    var nextArgs;
+    var boundCallback = function() {
+      var args = nextArgs;
+      nextArgs = null;
+      if (callback && args) {
+        callback.apply(component, args);
+      }
+    };
+    return function componentThrottleWrapper() {
+      var queueCall = !nextArgs;
+      nextArgs = slice.call(arguments);
+      if (queueCall) delayArg(boundCallback);
+    };
+  }
+
+  throw new Error('Second argument must be a delay function or number');
+};
+
+// Suppresses calls until the function is no longer called for that many
+// milliseconds. This should be used for delaying updates triggered by user
+// input, such as window resizing, or typing text that has a live preview or
+// client-side validation. This should not be used for inputs that trigger
+// server requests, such as search autocomplete; use debounceAsync for those
+// cases instead.
+//
+// Like component.bind(), will no longer call back once the component is
+// destroyed, which avoids possible bugs and memory leaks.
+Component.prototype.debounce = function(callback, delay) {
+  delay = delay || 0;
+  if (typeof delay !== 'number') {
+    throw new Error('Second argument must be a number');
+  }
+  var component = this;
+  this.on('destroy', function() {
+    // Reduce potential for memory leaks by removing references to the component
+    // and the passed in callback, which could have closure references
+    component = null;
+    // Cease calling back after component is removed from the DOM
+    callback = null;
+  });
+  var nextArgs;
+  var timeout;
+  var boundCallback = function() {
+    var args = nextArgs;
+    nextArgs = null;
+    timeout = null;
+    if (callback && args) {
+      callback.apply(component, args);
+    }
+  };
+  return function componentDebounceWrapper() {
+    nextArgs = slice.call(arguments);
+    if (timeout) clearTimeout(timeout);
+    timeout = setTimeout(boundCallback, delay);
+  };
+};
+
+// Forked from: https://github.com/juliangruber/async-debounce
+//
+// Like debounce(), suppresses calls until the function is no longer called for
+// that many milliseconds. In addition, suppresses calls while the callback
+// function is running. In other words, the callback will not be called again
+// until the supplied done() argument is called. This avoids the potential for
+// multiple callbacks to execute in parallel and complete out of order. It also
+// acts as an adaptive rate limiter. Use this method to debounce any field that
+// triggers an async call as the user types.
+//
+// Like component.bind(), will no longer call back once the component is
+// destroyed, which avoids possible bugs and memory leaks.
+Component.prototype.debounceAsync = function(callback, delay) {
+  var applyArguments = callback.length > 1;
+  delay = delay || 0;
+  if (typeof delay !== 'number') {
+    throw new Error('Second argument must be a number');
+  }
+  var component = this;
+  this.on('destroy', function() {
+    // Reduce potential for memory leaks by removing references to the component
+    // and the passed in callback, which could have closure references
+    component = null;
+    // Cease calling back after component is removed from the DOM
+    callback = null;
+  });
+  var running = false;
+  var nextArgs;
+  var timeout;
+  function done() {
+    var args = nextArgs;
+    nextArgs = null;
+    timeout = null;
+    if (callback && args) {
+      running = true;
+      args.push(done);
+      callback.apply(component, args);
+    } else {
+      running = false;
+    }
+  }
+  return function componentDebounceAsyncWrapper() {
+    nextArgs = (applyArguments) ? slice.call(arguments) : [];
+    if (timeout) clearTimeout(timeout);
+    if (running) return;
+    timeout = setTimeout(done, delay);
+  };
 };
 
 Component.prototype.get = function(viewName, unescaped) {

--- a/lib/components.js
+++ b/lib/components.js
@@ -69,7 +69,7 @@ Component.prototype.bind = function(callback) {
 // window.requestAnimationFrame or process.nextTick. If one of these is passed,
 // it will be used to create a single async call following any number of
 // synchronous calls. This mode is typically used to coalesce many synchronous
-// events (such as mulitple model events) into a single async event.
+// events (such as multiple model events) into a single async event.
 //
 // Like component.bind(), will no longer call back once the component is
 // destroyed, which avoids possible bugs and memory leaks.

--- a/lib/components.js
+++ b/lib/components.js
@@ -173,10 +173,14 @@ Component.prototype.debounce = function(callback, delay) {
 // Like debounce(), suppresses calls until the function is no longer called for
 // that many milliseconds. In addition, suppresses calls while the callback
 // function is running. In other words, the callback will not be called again
-// until the supplied done() argument is called. This avoids the potential for
-// multiple callbacks to execute in parallel and complete out of order. It also
-// acts as an adaptive rate limiter. Use this method to debounce any field that
-// triggers an async call as the user types.
+// until the supplied done() argument is called. When the debounced function is
+// called while the callback is running, the callback will be called again
+// immediately after done() is called. Thus, the callback will always receive
+// the last value passed to the debounced function.
+//
+// This avoids the potential for multiple callbacks to execute in parallel and
+// complete out of order. It also acts as an adaptive rate limiter. Use this
+// method to debounce any field that triggers an async call as the user types.
 //
 // Like component.bind(), will no longer call back once the component is
 // destroyed, which avoids possible bugs and memory leaks.

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   },
   "devDependencies": {
     "browserify": "^16.2.2",
-    "expect.js": "^0.3.1",
+    "chai": "^4.2.0",
     "express": "^4.13.3",
     "jshint": "^2.9.5",
-    "mocha": "^5.2.0"
+    "mocha": "^6.2.0"
   },
   "optionalDependencies": {},
   "bugs": {

--- a/test/all/eventmodel.mocha.js
+++ b/test/all/eventmodel.mocha.js
@@ -1,4 +1,4 @@
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var EventModel = require('../../lib/eventmodel');
 
 describe('eventmodel', function() {

--- a/test/browser/as.mocha.js
+++ b/test/browser/as.mocha.js
@@ -1,4 +1,4 @@
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var util = require('./util');
 var derby = util.derby;
 var expectHtml = util.expectHtml;
@@ -21,7 +21,7 @@ describe('as', function() {
     app.component('item', Item);
     var page = app.createPage();
     var fragment = page.getFragment('Body');
-    expect(page.nested[0]).an(Item);
+    expect(page.nested[0]).instanceof(Item);
     expectHtml(page.nested[0].markerNode.nextSibling, '<div></div>');
     expectHtml(fragment, '<div></div>');
   });
@@ -43,20 +43,20 @@ describe('as', function() {
     ]);
     var fragment = page.getFragment('Body');
 
-    expect(page.nested.map).only.keys('a', 'b', 'c');
+    expect(page.nested.map).all.keys('a', 'b', 'c');
     expectHtml(page.nested.map.a, '<li>A</li>');
     expectHtml(page.nested.map.b, '<li>B</li>');
     expectHtml(page.nested.map.c, '<li>C</li>');
     expectHtml(fragment, '<ul><li>A</li><li>B</li><li>C</li></ul>');
 
     page.model.remove('_page.items', 1);
-    expect(page.nested.map).only.keys('a', 'c');
+    expect(page.nested.map).all.keys('a', 'c');
     expectHtml(page.nested.map.a, '<li>A</li>');
     expectHtml(page.nested.map.c, '<li>C</li>');
     expectHtml(fragment, '<ul><li>A</li><li>C</li></ul>');
 
     page.model.unshift('_page.items', {id: 'd', text: 'D'});
-    expect(page.nested.map).only.keys('a', 'c', 'd');
+    expect(page.nested.map).all.keys('a', 'c', 'd');
     expectHtml(page.nested.map.a, '<li>A</li>');
     expectHtml(page.nested.map.c, '<li>C</li>');
     expectHtml(page.nested.map.d, '<li>D</li>');
@@ -89,28 +89,28 @@ describe('as', function() {
     ]);
     var fragment = page.getFragment('Body');
 
-    expect(page.nested.map).only.keys('a', 'b', 'c');
-    expect(page.nested.map.a).an(Item);
-    expect(page.nested.map.b).an(Item);
-    expect(page.nested.map.c).an(Item);
+    expect(page.nested.map).all.keys('a', 'b', 'c');
+    expect(page.nested.map.a).instanceof(Item);
+    expect(page.nested.map.b).instanceof(Item);
+    expect(page.nested.map.c).instanceof(Item);
     expectHtml(page.nested.map.a.markerNode.nextSibling, '<li>A</li>');
     expectHtml(page.nested.map.b.markerNode.nextSibling, '<li>B</li>');
     expectHtml(page.nested.map.c.markerNode.nextSibling, '<li>C</li>');
     expectHtml(fragment, '<ul><li>A</li><li>B</li><li>C</li></ul>');
 
     page.model.remove('_page.items', 1);
-    expect(page.nested.map).only.keys('a', 'c');
-    expect(page.nested.map.a).an(Item);
-    expect(page.nested.map.c).an(Item);
+    expect(page.nested.map).all.keys('a', 'c');
+    expect(page.nested.map.a).instanceof(Item);
+    expect(page.nested.map.c).instanceof(Item);
     expectHtml(page.nested.map.a.markerNode.nextSibling, '<li>A</li>');
     expectHtml(page.nested.map.c.markerNode.nextSibling, '<li>C</li>');
     expectHtml(fragment, '<ul><li>A</li><li>C</li></ul>');
 
     page.model.unshift('_page.items', {id: 'd', text: 'D'});
-    expect(page.nested.map).only.keys('a', 'c', 'd');
-    expect(page.nested.map.a).an(Item);
-    expect(page.nested.map.c).an(Item);
-    expect(page.nested.map.d).an(Item);
+    expect(page.nested.map).all.keys('a', 'c', 'd');
+    expect(page.nested.map.a).instanceof(Item);
+    expect(page.nested.map.c).instanceof(Item);
+    expect(page.nested.map.d).instanceof(Item);
     expectHtml(page.nested.map.a.markerNode.nextSibling, '<li>A</li>');
     expectHtml(page.nested.map.c.markerNode.nextSibling, '<li>C</li>');
     expectHtml(page.nested.map.d.markerNode.nextSibling, '<li>D</li>');
@@ -187,9 +187,9 @@ describe('as', function() {
 
     expect(page.nested.list).an('array');
     expect(page.nested.list).length(3);
-    expect(page.nested.list[0]).an(Item);
-    expect(page.nested.list[1]).an(Item);
-    expect(page.nested.list[2]).an(Item);
+    expect(page.nested.list[0]).instanceof(Item);
+    expect(page.nested.list[1]).instanceof(Item);
+    expect(page.nested.list[2]).instanceof(Item);
     expectHtml(page.nested.list[0].markerNode.nextSibling, '<li>A</li>');
     expectHtml(page.nested.list[1].markerNode.nextSibling, '<li>B</li>');
     expectHtml(page.nested.list[2].markerNode.nextSibling, '<li>C</li>');
@@ -197,17 +197,17 @@ describe('as', function() {
 
     page.model.remove('_page.items', 1);
     expect(page.nested.list).length(2);
-    expect(page.nested.list[0]).an(Item);
-    expect(page.nested.list[1]).an(Item);
+    expect(page.nested.list[0]).instanceof(Item);
+    expect(page.nested.list[1]).instanceof(Item);
     expectHtml(page.nested.list[0].markerNode.nextSibling, '<li>A</li>');
     expectHtml(page.nested.list[1].markerNode.nextSibling, '<li>C</li>');
     expectHtml(fragment, '<ul><li>A</li><li>C</li></ul>');
 
     page.model.unshift('_page.items', {id: 'd', text: 'D'});
     expect(page.nested.list).length(3);
-    expect(page.nested.list[0]).an(Item);
-    expect(page.nested.list[1]).an(Item);
-    expect(page.nested.list[2]).an(Item);
+    expect(page.nested.list[0]).instanceof(Item);
+    expect(page.nested.list[1]).instanceof(Item);
+    expect(page.nested.list[2]).instanceof(Item);
     expectHtml(page.nested.list[0].markerNode.nextSibling, '<li>D</li>');
     expectHtml(page.nested.list[1].markerNode.nextSibling, '<li>A</li>');
     expectHtml(page.nested.list[2].markerNode.nextSibling, '<li>C</li>');

--- a/test/browser/bindings.mocha.js
+++ b/test/browser/bindings.mocha.js
@@ -1,3 +1,4 @@
+var expect = require('chai').expect;
 var util = require('./util');
 var derby = util.derby;
 var expectHtml = util.expectHtml;

--- a/test/browser/components.js
+++ b/test/browser/components.js
@@ -1,3 +1,4 @@
+var expect = require('chai').expect;
 var templates = require('derby-templates').templates;
 var util = require('./util');
 var derby = util.derby;
@@ -272,10 +273,10 @@ describe('components', function() {
       var fragment = this.page.getFragment('Body');
       var swatch = this.page._components._1;
       expectHtml(fragment, '<div>Hide me.</div>');
-      expect(swatch.model.get('message')).a(templates.Template);
+      expect(swatch.model.get('message')).instanceof(templates.Template);
       swatch.model.set('show', true);
       expectHtml(fragment, '<div>Show me!</div>');
-      expect(swatch.model.get('message')).a(templates.Template);
+      expect(swatch.model.get('message')).instanceof(templates.Template);
     });
 
     it('updates within template attribute in model', function() {
@@ -297,10 +298,10 @@ describe('components', function() {
       var fragment = this.page.getFragment('Body');
       var swatch = this.page._components._1;
       expectHtml(fragment, '<div>Hide me.</div>');
-      expect(swatch.model.get('message')).a(templates.Template);
+      expect(swatch.model.get('message')).instanceof(templates.Template);
       swatch.model.set('show', true);
       expectHtml(fragment, '<div>Show me!</div>');
-      expect(swatch.model.get('message')).a(templates.Template);
+      expect(swatch.model.get('message')).instanceof(templates.Template);
     });
 
     it('updates within expression attribute by making it a template', function() {
@@ -322,7 +323,7 @@ describe('components', function() {
       var fragment = this.page.getFragment('Body');
       var swatch = this.page._components._1;
       expectHtml(fragment, '<div>Hide me.</div>');
-      expect(swatch.model.get('message')).a(templates.Template);
+      expect(swatch.model.get('message')).instanceof(templates.Template);
       expect(swatch.getAttribute('message')).equal('Hide me.');
       swatch.model.set('show', true);
       expectHtml(fragment, '<div>Show me!</div>');
@@ -346,7 +347,7 @@ describe('components', function() {
       var fragment = this.page.getFragment('Body');
       var swatch = this.page._components._1;
       expectHtml(fragment, '<div>Hide me.</div>');
-      expect(swatch.model.get('message')).a(templates.Template);
+      expect(swatch.model.get('message')).instanceof(templates.Template);
       expect(swatch.getAttribute('message')).equal('Hide me.');
       swatch.model.set('show', true);
       expectHtml(fragment, '<div>Show me!</div>');
@@ -449,8 +450,8 @@ describe('components', function() {
       var swatch = this.page._components._1;
       expectHtml(fragment, 'Hide me.Hide me.');
       expect(swatch.model.get('items').length).equal(2);
-      expect(swatch.model.get('items')[0].content).a(templates.Template);
-      expect(swatch.model.get('items')[1].content).a(templates.Template);
+      expect(swatch.model.get('items')[0].content).instanceof(templates.Template);
+      expect(swatch.model.get('items')[1].content).instanceof(templates.Template);
       swatch.model.set('show', true);
       expectHtml(fragment, 'Show me!Hide me.');
     });
@@ -482,8 +483,8 @@ describe('components', function() {
       var swatch = this.page._components._1;
       expectHtml(fragment, 'Hide me.Hide me.');
       expect(swatch.model.get('items').length).equal(2);
-      expect(swatch.model.get('items')[0].content).a(templates.Template);
-      expect(swatch.model.get('items')[1].content).a(templates.Template);
+      expect(swatch.model.get('items')[0].content).instanceof(templates.Template);
+      expect(swatch.model.get('items')[1].content).instanceof(templates.Template);
       swatch.model.set('show', true);
       expectHtml(fragment, 'Show me!Hide me.');
     });
@@ -545,7 +546,7 @@ describe('components', function() {
       var swatch = this.page._components._1;
       expectHtml(fragment, 'Hide me.Hide me.');
       expect(swatch.model.get('items').length).equal(2);
-      expect(swatch.model.get('items')[0].content).a(templates.Template);
+      expect(swatch.model.get('items')[0].content).instanceof(templates.Template);
       expect(swatch.model.get('items')[1].content).equal('Hide me.')
       swatch.model.set('show', true);
       expectHtml(fragment, 'Show me!Hide me.');

--- a/test/browser/dom-events.mocha.js
+++ b/test/browser/dom-events.mocha.js
@@ -1,4 +1,4 @@
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var util = require('./util');
 var derby = util.derby;
 var expectHtml = util.expectHtml;

--- a/test/browser/forms.js
+++ b/test/browser/forms.js
@@ -1,3 +1,4 @@
+var expect = require('chai').expect;
 var util = require('./util');
 var derby = util.derby;
 var expectHtml = util.expectHtml;

--- a/test/browser/util.js
+++ b/test/browser/util.js
@@ -1,4 +1,4 @@
-var expect = require('expect.js');
+var expect = require('chai').expect;
 var DerbyStandalone = require('../../lib/DerbyStandalone');
 var derby = new DerbyStandalone();
 require('derby-parsing');


### PR DESCRIPTION
Implement new prototype methods of Component that help to avoid bugs & memory leaks in async callbacks. Introduces the following methods:

* `fn = component.bind(callback)` – Returns a function that is bound to the component, similar to `fn = callback.bind(component)`. In addition, when the component is destroyed, stops calling the callback and removes its references to the component and the callback. This makes it simpler to avoid bugs that could occur if async functions executed after the component was removed from the page, and it helps to reduce memory leaks if the reference to the returned function is held by some other code outside of the component. Internally uses Function::apply, so not as performant as fat arrow functions, but it is a simple way to add a lot of safety around async function calling that should stop once rendering removes the component from the page.

* `fn = component.throttle(callback, [delayArg])` – Returns a function that is throttled with setTimeout or a custom delay function, such as `window.requestAnimationFrame`, `process.nextTick`, or `window.setImmediate`.  When passing in a numeric delay (or the default zero), calls the function at most once per that many milliseconds. Like Underscore, the function will be called on the leading and the trailing edge of the delay as appropriate. Unlike Underscore, calls are consistently called via setTimeout and are never synchronous. This should be used for reducing the frequency of ongoing updates, such as scroll events or other continuous streams of events. Additionally, implements an interface intended to be used with window.requestAnimationFrame or process.nextTick. If one of these is passed, it will be used to create a single async call following any number of synchronous calls. This mode is typically used to coalesce many synchronous events (such as multiple model events) into a single async event. Like component.bind(), will no longer call back once the component is destroyed, which avoids possible bugs and memory leaks.

* `fn = component.debounce(callback, [delay])` –  Suppresses calls until the function is no longer called for that many milliseconds. This should be used for delaying updates triggered by user input, such as window resizing, or typing text that has a live preview or client-side validation. This should not be used for inputs that trigger server requests, such as search autocomplete; use debounceAsync for those cases instead. Like component.bind(), will no longer call back once the component is destroyed, which avoids possible bugs and memory leaks.

* `fn = component.debounceAsync(callback, [delay])` –  Like debounce(), suppresses calls until the function is no longer called for that many milliseconds. In addition, suppresses calls while the callback function is running. In other words, the callback will not be called again until the supplied done() argument is called. When the debounced function is called while the callback is running, the callback will be called again immediately after done() is called. Thus, the callback will always receive the last value passed to the debounced function. This avoids the potential for multiple callbacks to execute in parallel and complete out of order. It also acts as an adaptive rate limiter. Use this method to debounce any field that triggers an async call as the user types.

In addition, this PR upgrades from expect.js to chai, which was needed for some new expect methods.