### PR TITLE
Component.view, component dependencies, and test utils

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -32,6 +32,7 @@ function App(derby, name, filename, options) {
   this.tracksRoutes = tracks.setup(this);
   this.model = null;
   this.page = null;
+  this._pendingComponentMap = {};
   this._init(options);
 }
 
@@ -218,8 +219,9 @@ App.prototype.component = function(name, constructor, isDependency) {
   // TODO: DRY. This is copy-pasted from derby-templates
   var mapName = viewName.replace(/:index$/, '');
   var currentView = this.views.nameMap[mapName];
-  var currentConstructor = currentView && currentView.componentFactory &&
-    currentView.componentFactory.constructor;
+  var currentConstructor = (currentView && currentView.componentFactory) ?
+    currentView.componentFactory.constructor :
+    this._pendingComponentMap[mapName];
 
   // Avoid registering the same component twice; we want to avoid the overhead
   // of loading view files from disk again. This is also what prevents
@@ -230,6 +232,21 @@ App.prototype.component = function(name, constructor, isDependency) {
   // dependencies from doing this without warning
   if (isDependency && currentView) {
     throw new Error('Dependencies cannot override existing views. Already registered "' + viewName + '"');
+  }
+
+  // This map is used to prevent infinite loops from circular dependencies
+  this._pendingComponentMap[mapName] = constructor;
+
+  // Recursively register component dependencies
+  if (viewDependencies) {
+    for (var i = 0; i < viewDependencies.length; i++) {
+      var dependency = viewDependencies[i];
+      if (Array.isArray(dependency)) {
+        this.component(dependency[0], dependency[1], true);
+      } else {
+        this.component(null, dependency, true);
+      }
+    }
   }
 
   // Register or find views specified by the component
@@ -258,19 +275,7 @@ App.prototype.component = function(name, constructor, isDependency) {
   // Associate the appropriate view with the component constructor
   view.componentFactory = components.createFactory(constructor);
 
-  // Recursively register component dependencies. This must be done after the
-  // containing component view is registered to prevent infinite loops from
-  // circular dependencies
-  if (viewDependencies) {
-    for (var i = 0; i < viewDependencies.length; i++) {
-      var dependency = viewDependencies[i];
-      if (Array.isArray(dependency)) {
-        this.component(dependency[0], dependency[1], true);
-      } else {
-        this.component(null, dependency, true);
-      }
-    }
-  }
+  delete this._pendingComponentMap[mapName];
 
   // Make chainable
   return this;

--- a/lib/App.js
+++ b/lib/App.js
@@ -176,6 +176,9 @@ App.prototype.loadViews = function() {};
 
 App.prototype.loadStyles = function() {};
 
+// This function is defined by requiring 'derby/parsing'
+App.prototype.addViews = null;
+
 App.prototype.component = function(viewName, constructor) {
   if (typeof viewName === 'function') {
     constructor = viewName;
@@ -183,13 +186,12 @@ App.prototype.component = function(viewName, constructor) {
   }
 
   var viewArg = constructor.view;
-  var viewIs, viewFilename, viewSource, viewOptions;
+  var viewIs, viewFilename, viewSource;
   // Always using an object for the static `view` property is preferred
   if (viewArg && typeof viewArg === 'object') {
     viewIs = viewArg.is;
     viewFilename = viewArg.file;
     viewSource = viewArg.source;
-    viewOptions = viewArg.options;
   } else {
     // Ignore other properties when `view` is an object. It is possible that
     // properties could be inherited from a parent component when extending it.
@@ -214,8 +216,9 @@ App.prototype.component = function(viewName, constructor) {
     view = this.views.find(viewName);
 
   } else if (viewSource) {
-    viewName = viewIs;
-    view = this.views.register(viewName, viewSource, viewOptions);
+    viewName = viewName || viewIs;
+    this.addViews(viewSource, viewName);
+    view = this.views.find(viewName);
 
   } else if (viewName) {
     view = this.views.find(viewName);

--- a/lib/App.js
+++ b/lib/App.js
@@ -177,8 +177,13 @@ App.prototype.loadViews = function() {};
 
 App.prototype.loadStyles = function() {};
 
-// This function is defined by requiring 'derby/parsing'
-App.prototype.addViews = null;
+// This function is overriden by requiring 'derby/parsing'
+App.prototype.addViews = function() {
+  throw new Error(
+    'Parsing not available. Registering a view from source should not be used ' +
+    'in application code. Instead, specify a filename with view.file.'
+  );
+};
 
 App.prototype.component = function(name, constructor, isDependency) {
   if (typeof name === 'function') {
@@ -189,14 +194,14 @@ App.prototype.component = function(name, constructor, isDependency) {
     throw new Error('Missing component constructor argument');
   }
 
-  var viewArg = constructor.view;
+  var viewProp = constructor.view;
   var viewIs, viewFilename, viewSource, viewDependencies;
   // Always using an object for the static `view` property is preferred
-  if (viewArg && typeof viewArg === 'object') {
-    viewIs = viewArg.is;
-    viewFilename = viewArg.file;
-    viewSource = viewArg.source;
-    viewDependencies = viewArg.dependencies;
+  if (viewProp && typeof viewProp === 'object') {
+    viewIs = viewProp.is;
+    viewFilename = viewProp.file;
+    viewSource = viewProp.source;
+    viewDependencies = viewProp.dependencies;
   } else {
     // Ignore other properties when `view` is an object. It is possible that
     // properties could be inherited from a parent component when extending it.

--- a/lib/App.js
+++ b/lib/App.js
@@ -181,39 +181,54 @@ App.prototype.component = function(viewName, constructor) {
     constructor = viewName;
     viewName = null;
   }
-  // DEPRECATED: constructor.prototype.name and constructor.prototype.view
-  // use the equivalent static properties instead
-  var constructorIs = constructor.is || constructor.prototype.name;
-  var viewArg = constructor.view || constructor.prototype.view;
 
-  var viewFilename;
-  var viewSource;
-  var viewOptions;
-  if (typeof viewArg === 'string') {
-    viewFilename = viewArg;
-  } else if (viewArg) {
+  var viewArg = constructor.view;
+  var viewIs, viewFilename, viewSource, viewOptions;
+  // Always using an object for the static `view` property is preferred
+  if (viewArg && typeof viewArg === 'object') {
+    viewIs = viewArg.is;
+    viewFilename = viewArg.file;
     viewSource = viewArg.source;
     viewOptions = viewArg.options;
+  } else {
+    // Ignore other properties when `view` is an object. It is possible that
+    // properties could be inherited from a parent component when extending it.
+    //
+    // DEPRECATED: constructor.prototype.name and constructor.prototype.view
+    // use the equivalent static properties instead
+    viewIs = constructor.is || constructor.prototype.name;
+    viewFilename = constructor.view || constructor.prototype.view;
+  }
+
+  if (viewFilename && viewSource) {
+    throw new Error('Component may not specify both a view file and source');
   }
 
   // Inherit from Component
   components.extendComponent(constructor);
 
+  var view;
   if (viewFilename) {
-    viewName = viewName || constructorIs || path.basename(viewFilename, '.html');
+    viewName = viewName || viewIs || path.basename(viewFilename, '.html');
     this.loadViews(viewFilename, viewName);
+    view = this.views.find(viewName);
 
-  } else if (!viewName) {
-    if (constructorIs) {
-      viewName = constructorIs;
-      this.views.register(viewName, viewSource || '', viewOptions);
-    } else {
-      throw new Error('No view name specified for component');
-    }
+  } else if (viewSource) {
+    viewName = viewIs;
+    view = this.views.register(viewName, viewSource, viewOptions);
+
+  } else if (viewName) {
+    view = this.views.find(viewName);
+
+  } else if (viewIs) {
+    viewName = viewIs;
+    view = this.views.register(viewName, '');
+
+  } else {
+    throw new Error('No view specified for component');
   }
 
-  // Associate the appropriate view with the component type
-  var view = this.views.find(viewName);
+  // Associate the appropriate view with the component constructor
   if (!view) {
     var message = this.views.findErrorMessage(viewName);
     throw new Error(message);

--- a/lib/App.js
+++ b/lib/App.js
@@ -186,12 +186,13 @@ App.prototype.component = function(viewName, constructor) {
   }
 
   var viewArg = constructor.view;
-  var viewIs, viewFilename, viewSource;
+  var viewIs, viewFilename, viewSource, viewDependencies;
   // Always using an object for the static `view` property is preferred
   if (viewArg && typeof viewArg === 'object') {
     viewIs = viewArg.is;
     viewFilename = viewArg.file;
     viewSource = viewArg.source;
+    viewDependencies = viewArg.dependencies;
   } else {
     // Ignore other properties when `view` is an object. It is possible that
     // properties could be inherited from a parent component when extending it.
@@ -204,6 +205,17 @@ App.prototype.component = function(viewName, constructor) {
 
   if (viewFilename && viewSource) {
     throw new Error('Component may not specify both a view file and source');
+  }
+
+  if (viewDependencies) {
+    for (var i = 0; i < viewDependencies.length; i++) {
+      var dependency = viewDependencies[i];
+      if (Array.isArray(dependency)) {
+        this.component(dependency[0], dependency[1]);
+      } else {
+        this.component(dependency);
+      }
+    }
   }
 
   // Inherit from Component

--- a/lib/App.js
+++ b/lib/App.js
@@ -179,10 +179,13 @@ App.prototype.loadStyles = function() {};
 // This function is defined by requiring 'derby/parsing'
 App.prototype.addViews = null;
 
-App.prototype.component = function(viewName, constructor) {
-  if (typeof viewName === 'function') {
-    constructor = viewName;
-    viewName = null;
+App.prototype.component = function(name, constructor, isDependency) {
+  if (typeof name === 'function') {
+    constructor = name;
+    name = null;
+  }
+  if (typeof constructor !== 'function') {
+    throw new Error('Missing component constructor argument');
   }
 
   var viewArg = constructor.view;
@@ -202,53 +205,72 @@ App.prototype.component = function(viewName, constructor) {
     viewIs = constructor.is || constructor.prototype.name;
     viewFilename = constructor.view || constructor.prototype.view;
   }
+  var viewName = name || viewIs ||
+    (viewFilename && path.basename(viewFilename, '.html'));
 
+  if (!viewName) {
+    throw new Error('No view specified for component');
+  }
   if (viewFilename && viewSource) {
     throw new Error('Component may not specify both a view file and source');
   }
 
-  if (viewDependencies) {
-    for (var i = 0; i < viewDependencies.length; i++) {
-      var dependency = viewDependencies[i];
-      if (Array.isArray(dependency)) {
-        this.component(dependency[0], dependency[1]);
-      } else {
-        this.component(dependency);
-      }
-    }
+  // TODO: DRY. This is copy-pasted from derby-templates
+  var mapName = viewName.replace(/:index$/, '');
+  var currentView = this.views.nameMap[mapName];
+  var currentConstructor = currentView && currentView.componentFactory &&
+    currentView.componentFactory.constructor;
+
+  // Avoid registering the same component twice; we want to avoid the overhead
+  // of loading view files from disk again. This is also what prevents
+  // circular dependencies from infinite looping
+  if (currentConstructor === constructor) return;
+
+  // Calling app.component() overrides existing views or components. Prevent
+  // dependencies from doing this without warning
+  if (isDependency && currentView) {
+    throw new Error('Dependencies cannot override existing views. Already registered "' + viewName + '"');
   }
 
-  // Inherit from Component
-  components.extendComponent(constructor);
-
+  // Register or find views specified by the component
   var view;
   if (viewFilename) {
-    viewName = viewName || viewIs || path.basename(viewFilename, '.html');
     this.loadViews(viewFilename, viewName);
     view = this.views.find(viewName);
 
   } else if (viewSource) {
-    viewName = viewName || viewIs;
     this.addViews(viewSource, viewName);
     view = this.views.find(viewName);
 
-  } else if (viewName) {
+  } else if (name) {
     view = this.views.find(viewName);
 
-  } else if (viewIs) {
-    viewName = viewIs;
-    view = this.views.register(viewName, '');
-
   } else {
-    throw new Error('No view specified for component');
+    view = this.views.register(viewName, '');
   }
-
-  // Associate the appropriate view with the component constructor
   if (!view) {
     var message = this.views.findErrorMessage(viewName);
     throw new Error(message);
   }
+
+  // Inherit from Component
+  components.extendComponent(constructor);
+  // Associate the appropriate view with the component constructor
   view.componentFactory = components.createFactory(constructor);
+
+  // Recursively register component dependencies. This must be done after the
+  // containing component view is registered to prevent infinite loops from
+  // circular dependencies
+  if (viewDependencies) {
+    for (var i = 0; i < viewDependencies.length; i++) {
+      var dependency = viewDependencies[i];
+      if (Array.isArray(dependency)) {
+        this.component(dependency[0], dependency[1], true);
+      } else {
+        this.component(null, dependency, true);
+      }
+    }
+  }
 
   // Make chainable
   return this;

--- a/lib/App.js
+++ b/lib/App.js
@@ -181,9 +181,20 @@ App.prototype.component = function(viewName, constructor) {
     constructor = viewName;
     viewName = null;
   }
-  // DEPRECATED: constructor.prototype.view and constructor.prototype.name
-  var viewFilename = constructor.view || constructor.prototype.view;
+  // DEPRECATED: constructor.prototype.name and constructor.prototype.view
+  // use the equivalent static properties instead
   var constructorIs = constructor.is || constructor.prototype.name;
+  var viewArg = constructor.view || constructor.prototype.view;
+
+  var viewFilename;
+  var viewSource;
+  var viewOptions;
+  if (typeof viewArg === 'string') {
+    viewFilename = viewArg;
+  } else if (viewArg) {
+    viewSource = viewArg.source;
+    viewOptions = viewArg.options;
+  }
 
   // Inherit from Component
   components.extendComponent(constructor);
@@ -195,8 +206,7 @@ App.prototype.component = function(viewName, constructor) {
   } else if (!viewName) {
     if (constructorIs) {
       viewName = constructorIs;
-      var view = this.views.register(viewName);
-      view.template = templates.emptyTemplate;
+      this.views.register(viewName, viewSource || '', viewOptions);
     } else {
       throw new Error('No view name specified for component');
     }

--- a/lib/parsing/index.js
+++ b/lib/parsing/index.js
@@ -2,6 +2,12 @@
 exports = module.exports = require('derby-parsing');
 var htmlUtil = require('html-util');
 var path = require('path');
+var App = require('../App');
+
+App.prototype.addViews = function(file, namespace) {
+  var views = exports.parseViews(file, namespace);
+  exports.registerParsedViews(this, views);
+};
 
 exports.getImportNamespace = function(namespace, attrs, importFilename) {
   var extension = path.extname(importFilename);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha test/all/*.mocha.js; ./node_modules/.bin/jshint lib/*.js test/*.js"
+    "test": "./node_modules/.bin/mocha test/all/*.mocha.js; ./node_modules/.bin/jshint lib/*.js test/*.js test-utils/*.js"
   },
   "dependencies": {
     "chokidar": "^3.1.1",

--- a/test-utils/ComponentHarness.js
+++ b/test-utils/ComponentHarness.js
@@ -28,30 +28,30 @@ ComponentHarness.prototype.setup = function(source) {
   }
   return this;
 };
-ComponentHarness.prototype.getInstance = function() {
-  // HACK: Implement getting an instance as a side-effect of HTML rendering.
-  // This code relies on the fact that while rendering HTML, components are
-  // instantiated, and a reference is kept on page._components. Since we just
-  // created the page, we can reliably return the first component.
+ComponentHarness.prototype.renderHtml = function() {
+  return this._get(function(page) {
+    page.html = page.get('$harness');
+  });
+};
+ComponentHarness.prototype.renderDom = function() {
+  return this._get(function(page) {
+    page.fragment = page.getFragment('$harness');
+  });
+};
+ComponentHarness.prototype._get = function(render) {
+  var page = new this.app.Page(this.app, this.model);
+  render(page);
+  // HACK: Implement getting an instance as a side-effect of rendering. This
+  // code relies on the fact that while rendering, components are instantiated,
+  // and a reference is kept on page._components. Since we just created the
+  // page, we can reliably return the first component.
   //
   // The more standard means for getting a reference to a component controller
-  // would be to add a hooks in the view with `as=` or `on-init=`. However,
-  // we want the developer to pass this view in, so they can supply whatever
+  // would be to add a hooks in the view with `as=` or `on-init=`. However, we
+  // want the developer to pass this view in, so they can supply whatever
   // harness context they like.
   //
   // This may need to be updated if the internal workings of Derby change.
-  var page = this._createPage();
-  page.get('$harness');
-  return page._components._1;
-};
-ComponentHarness.prototype.getHtml = function() {
-  var page = this._createPage();
-  return page.get('$harness');
-};
-ComponentHarness.prototype.getFragment = function() {
-  var page = this._createPage();
-  return page.getFragment('$harness');
-};
-ComponentHarness.prototype._createPage = function() {
-  return new this.app.Page(this.app, this.model);
+  page.component = page._components._1;
+  return page;
 };

--- a/test-utils/ComponentHarness.js
+++ b/test-utils/ComponentHarness.js
@@ -28,19 +28,20 @@ ComponentHarness.prototype.setup = function(source) {
   }
   return this;
 };
-ComponentHarness.prototype.skip = function() {
+
+ComponentHarness.prototype.stub = function() {
   for (var i = 0; i < arguments.length; i++) {
     var name = arguments[i];
     this.app.views.register(name, '');
   }
   return this;
 };
-ComponentHarness.prototype.mock = function() {
+ComponentHarness.prototype.stubComponent = function() {
   for (var i = 0; i < arguments.length; i++) {
     var arg = arguments[i];
     var options = (typeof arg === 'string') ? {is: arg} : arg;
-    var mock = createMock(options);
-    this.app.component(mock);
+    var Stub = createStubComponent(options);
+    this.app.component(Stub);
   }
   return this;
 };
@@ -78,20 +79,20 @@ ComponentHarness.prototype._get = function(render) {
   page.component = page._components._1;
   return page;
 };
-ComponentHarness.createMock = createMock;
+ComponentHarness.createStubComponent = createStubComponent;
 
-function createMock(options) {
+function createStubComponent(options) {
   var as = options.as || options.is;
   var asArray = options.asArray;
 
-  function ComponentMock() {}
-  ComponentMock.view = {
+  function StubComponent() {}
+  StubComponent.view = {
     is: options.is,
     file: options.file,
     source: options.source,
     dependencies: options.dependencies
   };
-  ComponentMock.prototype.init = (asArray) ?
+  StubComponent.prototype.init = (asArray) ?
     function() {
       var page = this.page;
       var component = this;
@@ -113,5 +114,5 @@ function createMock(options) {
         page[as] = undefined;
       });
     };
-  return ComponentMock;
+  return StubComponent;
 }

--- a/test-utils/ComponentHarness.js
+++ b/test-utils/ComponentHarness.js
@@ -29,6 +29,17 @@ ComponentHarness.prototype.setup = function(source) {
   return this;
 };
 ComponentHarness.prototype.getInstance = function() {
+  // HACK: Implement getting an instance as a side-effect of HTML rendering.
+  // This code relies on the fact that while rendering HTML, components are
+  // instantiated, and a reference is kept on page._components. Since we just
+  // created the page, we can reliably return the first component.
+  //
+  // The more standard means for getting a reference to a component controller
+  // would be to add a hooks in the view with `as=` or `on-init=`. However,
+  // we want the developer to pass this view in, so they can supply whatever
+  // harness context they like.
+  //
+  // This may need to be updated if the internal workings of Derby change.
   var page = this._createPage();
   page.get('$harness');
   return page._components._1;

--- a/test-utils/ComponentHarness.js
+++ b/test-utils/ComponentHarness.js
@@ -54,6 +54,13 @@ ComponentHarness.prototype.renderDom = function() {
     page.fragment = page.getFragment('$harness');
   });
 };
+ComponentHarness.prototype.attachTo = function(parentNode, node) {
+  return this._get(function(page) {
+    var view = page.getView('$harness');
+    var targetNode = node || parentNode.firstChild;
+    view.attachTo(parentNode, targetNode, page.context);
+  });
+};
 ComponentHarness.prototype._get = function(render) {
   var page = new this.app.Page(this.app, this.model);
   render(page);

--- a/test-utils/ComponentHarness.js
+++ b/test-utils/ComponentHarness.js
@@ -1,0 +1,46 @@
+var Model = require('racer').Model;
+var App = require('../lib/App');
+require('../parsing');
+
+function HarnessApp() {
+  App.call(this);
+}
+HarnessApp.prototype = Object.create(App.prototype);
+// Disable App.prototype._init(), which does setup for loading views
+// from files on the server and loading serialized views and data
+// on the client
+HarnessApp.prototype._init = function() {};
+
+module.exports = ComponentHarness;
+function ComponentHarness() {
+  this.app = new HarnessApp();
+  this.model = new Model();
+  if (arguments.length > 0) {
+    this.setup.apply(this, arguments);
+  }
+}
+ComponentHarness.prototype.setup = function(source) {
+  this.app.views.register('$harness', source);
+  // Remaining variable arguments are components
+  for (var i = 1; i < arguments.length; i++) {
+    var constructor = arguments[i];
+    this.app.component(constructor);
+  }
+  return this;
+};
+ComponentHarness.prototype.getInstance = function() {
+  var page = this._createPage();
+  page.get('$harness');
+  return page._components._1;
+};
+ComponentHarness.prototype.getHtml = function() {
+  var page = this._createPage();
+  return page.get('$harness');
+};
+ComponentHarness.prototype.getFragment = function() {
+  var page = this._createPage();
+  return page.getFragment('$harness');
+};
+ComponentHarness.prototype._createPage = function() {
+  return new this.app.Page(this.app, this.model);
+};

--- a/test-utils/assertions.js
+++ b/test-utils/assertions.js
@@ -1,9 +1,6 @@
 module.exports = function(domWindow, Assertion) {
-  if (!domWindow) domWindow = window;
-  var domDocument = domWindow.document;
-  var domNode = domWindow.Node;
-
   function removeComments(node) {
+    var domDocument = (domWindow || window).document;
     var clone = domDocument.importNode(node, true);
     // last two arguments for createTreeWalker are required in IE
     // NodeFilter.SHOW_COMMENT === 128
@@ -19,6 +16,7 @@ module.exports = function(domWindow, Assertion) {
   }
 
   function getHtml(node, parentTag) {
+    var domDocument = (domWindow || window).document;
     var el = domDocument.createElement(parentTag || 'ins');
     var clone = domDocument.importNode(node, true);
     el.appendChild(clone);
@@ -30,6 +28,7 @@ module.exports = function(domWindow, Assertion) {
       var obj = this._obj;
       var includeComments = options && options.includeComments;
       var parentTag = options && options.parentTag;
+      var domNode = (domWindow || window).Node;
 
       new Assertion(obj).instanceOf(domNode);
       new Assertion(expected).is.a('string');

--- a/test-utils/assertions.js
+++ b/test-utils/assertions.js
@@ -17,6 +17,12 @@ module.exports = function(domWindow, Assertion) {
 
   function getHtml(node, parentTag) {
     var domDocument = (domWindow || window).document;
+    // We use the <ins> element, because it has a transparent content model:
+    // https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Transparent_content_model
+    //
+    // In practice, DOM validity isn't enforced by browsers when using
+    // appendChild and innerHTML, so specifying a valid parentTag for the node
+    // should not be necessary
     var el = domDocument.createElement(parentTag || 'ins');
     var clone = domDocument.importNode(node, true);
     el.appendChild(clone);

--- a/test-utils/assertions.js
+++ b/test-utils/assertions.js
@@ -1,0 +1,54 @@
+module.exports = function(domWindow, Assertion) {
+  if (!domWindow) domWindow = window;
+  var domDocument = domWindow.document;
+  var domNode = domWindow.Node;
+
+  function removeComments(node) {
+    var clone = domDocument.importNode(node, true);
+    // last two arguments for createTreeWalker are required in IE
+    // NodeFilter.SHOW_COMMENT === 128
+    var treeWalker = domDocument.createTreeWalker(clone, 128, null, false);
+    var toRemove = [];
+    for (var item; item = treeWalker.nextNode();) {
+      toRemove.push(item);
+    }
+    for (var i = toRemove.length; i--;) {
+      toRemove[i].parentNode.removeChild(toRemove[i]);
+    }
+    return clone;
+  }
+
+  function getHtml(node, parentTag) {
+    var el = domDocument.createElement(parentTag || 'ins');
+    var clone = domDocument.importNode(node, true);
+    el.appendChild(clone);
+    return el.innerHTML;
+  }
+
+  if (Assertion) {
+    Assertion.addMethod('html', function(expected, options) {
+      var obj = this._obj;
+      var includeComments = options && options.includeComments;
+      var parentTag = options && options.parentTag;
+
+      new Assertion(obj).instanceOf(domNode);
+      new Assertion(expected).is.a('string');
+
+      var fragment = (includeComments) ? obj : removeComments(obj);
+      var html = getHtml(fragment, parentTag);
+
+      this.assert(
+        html === expected,
+        'expected the HTML #{exp} but got #{act}',
+        'expected to not have HTML #{act}',
+        expected,
+        html
+      );
+    });
+  }
+
+  return {
+    removeComments: removeComments,
+    getHtml: getHtml
+  };
+};

--- a/test-utils/index.js
+++ b/test-utils/index.js
@@ -1,0 +1,1 @@
+exports.assertions = require('./assertions');

--- a/test-utils/index.js
+++ b/test-utils/index.js
@@ -1,1 +1,2 @@
 exports.assertions = require('./assertions');
+exports.ComponentHarness = require('./ComponentHarness');

--- a/test/all/ComponentHarness.mocha.js
+++ b/test/all/ComponentHarness.mocha.js
@@ -31,7 +31,7 @@ describe('ComponentHarness', function() {
       function Box() {}
       Box.view = {
         is: 'box',
-        source: '<div class="box"></div>'
+        source: '<index:><div class="box"></div>'
       };
       var html = new ComponentHarness('<view is="box" />', Box).getHtml();
       expect(html).equal('<div class="box"></div>');
@@ -45,7 +45,7 @@ describe('ComponentHarness', function() {
       function Box() {}
       Box.view = {
         is: 'box',
-        source: '<div class="box"></div>'
+        source: '<index:><div class="box"></div>'
       };
       var fragment = new ComponentHarness('<view is="box" />', Box).getFragment();
       expect(fragment).instanceof(DocumentFragment);

--- a/test/all/ComponentHarness.mocha.js
+++ b/test/all/ComponentHarness.mocha.js
@@ -1,0 +1,51 @@
+var expect = require('chai').expect;
+var testUtils = require('../../test-utils');
+var ComponentHarness = testUtils.ComponentHarness;
+
+describe('ComponentHarness', function() {
+  describe('getInstance', function() {
+    it('creates a component instance', function() {
+      function Box() {}
+      Box.is = 'box';
+      var box = new ComponentHarness('<view is="box" />', Box).getInstance();
+      expect(box).instanceof(Box);
+    });
+    it('Can pass a value to a component instance from harness template', function() {
+      function Box() {}
+      Box.is = 'box';
+      var box = new ComponentHarness('<view is="box" value="Hi" />', Box).getInstance();
+      expect(box.model.get('value')).equal('Hi');
+    });
+    it('Can pass a value to a component instance from harness model', function() {
+      function Box() {}
+      Box.is = 'box';
+      var harness = new ComponentHarness('<view is="box" value="{{_page.message}}" />', Box);
+      harness.model.set('_page.message', 'Yo.');
+      var box = harness.getInstance();
+      expect(box.model.get('value')).equal('Yo.');
+    });
+  });
+
+  describe('getHtml', function() {
+    it('Returns HTML', function() {
+      function Box() {}
+      Box.is = 'box';
+      Box.view = {source: '<div class="box"></div>'};
+      var html = new ComponentHarness('<view is="box" />', Box).getHtml();
+      expect(html).equal('<div class="box"></div>');
+    });
+  });
+
+  describe('getFragment', function() {
+    if (typeof document === 'undefined') return;
+
+    it('Returns a DocumentFragment', function() {
+      function Box() {}
+      Box.is = 'box';
+      Box.view = {source: '<div class="box"></div>'};
+      var fragment = new ComponentHarness('<view is="box" />', Box).getFragment();
+      expect(fragment).instanceof(DocumentFragment);
+      expect(fragment).html('<div class="box"></div>');
+    });
+  });
+});

--- a/test/all/ComponentHarness.mocha.js
+++ b/test/all/ComponentHarness.mocha.js
@@ -160,7 +160,37 @@ describe('ComponentHarness', function() {
   describe('render assertion', function() {
     if (typeof document === 'undefined') return;
 
-    it('checks component HTML, DOM, and attachment rendering', function() {
+    it('checks equivalence of HTML, DOM, and attachment rendering', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source: '<index:><div class="box"></div>'
+      };
+      var harness = new ComponentHarness('<view is="box" />', Box);
+      expect(harness).to.render();
+    });
+
+    it('fails because of non-equivalent invalid HTML', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source: '<index:><p><div></div></p>'
+      };
+      var harness = new ComponentHarness('<view is="box" />', Box);
+      expect(harness).not.to.render();
+    });
+
+    it('fails because of non-equivalent optional HTML element', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source: '<index:><table><tr><td></td></tr></table>'
+      };
+      var harness = new ComponentHarness('<view is="box" />', Box);
+      expect(harness).not.to.render();
+    });
+
+    it('checks harness HTML, DOM, and attachment rendering against html', function() {
       function Box() {}
       Box.view = {
         is: 'box',
@@ -272,7 +302,7 @@ describe('ComponentHarness', function() {
         source:
           '<index:>' +
             '<div class="clown mock"></div>'
-      }
+      };
       var html = new ComponentHarness('<view is="box" />', Box, ClownMock).renderHtml().html;
       expect(html).equal('<div class="box"><div class="clown mock"></div></div>');
     });

--- a/test/all/ComponentHarness.mocha.js
+++ b/test/all/ComponentHarness.mocha.js
@@ -156,4 +156,238 @@ describe('ComponentHarness', function() {
       expect(box.myClown).instanceof(Clown);
     });
   });
+  describe('setup', function() {
+    it('can be called after instantiation to configure a harness', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source: '<index:><div class="box"></div>'
+      };
+      var harness = new ComponentHarness();
+      var html = harness.setup('<view is="box" />', Box).renderHtml().html;
+      expect(html).equal('<div class="box"></div>');
+    });
+  });
+
+  describe('dependencies', function() {
+    it('registers component dependencies', function() {
+      function Clown() {}
+      Clown.view = {
+        is: 'clown',
+        source:
+          '<index:>' +
+            '<div class="clown"></div>'
+      };
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view is="clown" />' +
+            '</div>',
+        dependencies: [Clown]
+      };
+      var html = new ComponentHarness('<view is="box" />', Box).renderHtml().html;
+      expect(html).equal('<div class="box"><div class="clown"></div></div>');
+    });
+
+    it('can specify custom name for a dependency', function() {
+      function Clown() {}
+      Clown.view = {
+        is: 'clown',
+        source:
+          '<index:>' +
+            '<div class="clown"></div>'
+      };
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view is="my-precious" />' +
+            '</div>',
+        dependencies: [
+          ['my-precious', Clown]
+        ]
+      };
+      var html = new ComponentHarness('<view is="box" />', Box).renderHtml().html;
+      expect(html).equal('<div class="box"><div class="clown"></div></div>');
+    });
+
+    it('overrides component dependency with custom mock', function() {
+      function Clown() {}
+      Clown.view = {
+        is: 'clown',
+        source:
+          '<index:>' +
+            '<div class="clown"></div>'
+      };
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view is="clown" />' +
+            '</div>',
+        dependencies: [Clown]
+      };
+      function ClownMock() {}
+      ClownMock.view = {
+        is: 'clown',
+        source:
+          '<index:>' +
+            '<div class="clown mock"></div>'
+      }
+      var html = new ComponentHarness('<view is="box" />', Box, ClownMock).renderHtml().html;
+      expect(html).equal('<div class="box"><div class="clown mock"></div></div>');
+    });
+  });
+
+  describe('mock', function() {
+    it('defines an empty view and creates a property on page by name', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view is="clown" expression="happy" />' +
+            '</div>'
+      };
+      var page = new ComponentHarness('<view is="box" />', Box)
+        .mock('clown').renderHtml();
+      expect(page.html).equal('<div class="box"></div>');
+      expect(page.clown.model.get('expression')).equal('happy');
+    });
+
+    it('supports as option', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view is="clown" expression="happy" />' +
+            '</div>'
+      };
+      var page = new ComponentHarness('<view is="box" />', Box)
+        .mock({is: 'clown', as: 'myClown'}).renderHtml();
+      expect(page.html).equal('<div class="box"></div>');
+      expect(page.myClown.model.get('expression')).equal('happy');
+    });
+
+    it('supports asArray option', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view is="clown" expression="happy" />' +
+              '<view is="clown" expression="sad" />' +
+            '</div>'
+      };
+      var page = new ComponentHarness('<view is="box" />', Box)
+        .mock({is: 'clown', asArray: 'clowns'}).renderHtml();
+      expect(page.html).equal('<div class="box"></div>');
+      expect(page.clowns.length).equal(2);
+      expect(page.clowns[0].model.get('expression')).equal('happy');
+      expect(page.clowns[1].model.get('expression')).equal('sad');
+    });
+
+    it('can be created via static createMock() method', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view is="clown" expression="happy" />' +
+            '</div>'
+      };
+      var ClownMock = ComponentHarness.createMock({is: 'clown'});
+      var page = new ComponentHarness('<view is="box" />', Box, ClownMock).renderHtml();
+      expect(page.html).equal('<div class="box"></div>');
+      expect(page.clown.model.get('expression')).equal('happy');
+    });
+
+    it('can supply options to createMock() method', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view is="clown" expression="happy" />' +
+            '</div>'
+      };
+      var ClownMock = ComponentHarness.createMock({is: 'clown', as: 'myClown'});
+      var page = new ComponentHarness('<view is="box" />', Box, ClownMock).renderHtml();
+      expect(page.html).equal('<div class="box"></div>');
+      expect(page.myClown.model.get('expression')).equal('happy');
+    });
+
+    it('can supply source to createMock() method', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view is="clown" expression="happy" />' +
+            '</div>'
+      };
+      var ClownMock = ComponentHarness.createMock({
+        is: 'clown',
+        source: '<index:><div class="mock clown"></div>'
+      });
+      var page = new ComponentHarness('<view is="box" />', Box, ClownMock).renderHtml();
+      expect(page.html).equal('<div class="box"><div class="mock clown"></div></div>');
+      expect(page.clown.model.get('expression')).equal('happy');
+    });
+  });
+
+  describe('skip', function() {
+    it('defines empty views by name', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view is="clown" />' +
+              '<view is="ball" />' +
+              '<view is="puppy" />' +
+            '</div>'
+      };
+      var html = new ComponentHarness('<view is="box" />', Box)
+        .skip('clown', 'ball', 'puppy').renderHtml().html;
+      expect(html).equal('<div class="box"></div>');
+    });
+
+    it('overrides a component dependency with an empty view', function() {
+      function Clown() {}
+      Clown.view = {
+        is: 'clown',
+        source:
+          '<index:>' +
+            '<div class="clown"></div>'
+      };
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view is="clown" />' +
+            '</div>',
+        dependencies: [Clown]
+      };
+      var html = new ComponentHarness('<view is="box" />', Box).skip('clown').renderHtml().html;
+      expect(html).equal('<div class="box"></div>');
+    });
+  });
 });

--- a/test/all/ComponentHarness.mocha.js
+++ b/test/all/ComponentHarness.mocha.js
@@ -156,6 +156,38 @@ describe('ComponentHarness', function() {
       expect(box.myClown).instanceof(Clown);
     });
   });
+
+  describe('render assertion', function() {
+    if (typeof document === 'undefined') return;
+
+    it('checks component HTML, DOM, and attachment rendering', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source: '<index:><div class="box"></div>'
+      };
+      var harness = new ComponentHarness('<view is="box" />', Box);
+      expect(harness).to.render('<div class="box"></div>');
+    });
+
+    it('fails to attach due to invalid HTML', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source: '<index:><p><div></div></p>'
+      };
+      var harness = new ComponentHarness('<view is="box" />', Box);
+      expect(harness).not.to.render('<p><div></div></p>');
+    });
+
+    it('passes with blank view', function() {
+      function Box() {}
+      Box.view = {is: 'box'};
+      var harness = new ComponentHarness('<view is="box" />', Box);
+      expect(harness).to.render('');
+    });
+  });
+
   describe('setup', function() {
     it('can be called after instantiation to configure a harness', function() {
       function Box() {}

--- a/test/all/ComponentHarness.mocha.js
+++ b/test/all/ComponentHarness.mocha.js
@@ -1,55 +1,159 @@
 var expect = require('chai').expect;
-var testUtils = require('../../test-utils');
-var ComponentHarness = testUtils.ComponentHarness;
+var ComponentHarness = require('../../test-utils').ComponentHarness;
 
 describe('ComponentHarness', function() {
-  describe('getInstance', function() {
-    it('creates a component instance', function() {
+  describe('renderHtml', function() {
+    it('returns a page object', function() {
       function Box() {}
       Box.view = {is: 'box'};
-      var box = new ComponentHarness('<view is="box" />', Box).getInstance();
+      var harness = new ComponentHarness('<view is="box" />', Box);
+      var page = harness.renderHtml();
+      expect(page).instanceof(harness.app.Page);
+    });
+
+    it('sets component property on returned object', function() {
+      function Box() {}
+      Box.view = {is: 'box'};
+      var box = new ComponentHarness('<view is="box" />', Box).renderHtml().component;
       expect(box).instanceof(Box);
     });
-    it('Can pass a value to a component instance from harness template', function() {
+
+    it('sets html property on returned object', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source: '<index:><div class="box"></div>'
+      };
+      var html = new ComponentHarness('<view is="box" />', Box).renderHtml().html;
+      expect(html).equal('<div class="box"></div>');
+    });
+
+    it('passes a value to a component instance from harness template', function() {
       function Box() {}
       Box.view = {is: 'box'};
-      var box = new ComponentHarness('<view is="box" value="Hi" />', Box).getInstance();
+      var box = new ComponentHarness('<view is="box" value="Hi" />', Box).renderHtml().component;
       expect(box.model.get('value')).equal('Hi');
     });
-    it('Can pass a value to a component instance from harness model', function() {
+
+    it('passes a value to a component instance from harness model', function() {
       function Box() {}
       Box.view = {is: 'box'};
       var harness = new ComponentHarness('<view is="box" value="{{_page.message}}" />', Box);
       harness.model.set('_page.message', 'Yo.');
-      var box = harness.getInstance();
+      var box = harness.renderHtml().component;
       expect(box.model.get('value')).equal('Yo.');
     });
-  });
 
-  describe('getHtml', function() {
-    it('Returns HTML', function() {
+    it('renders view partials', function() {
       function Box() {}
       Box.view = {
         is: 'box',
-        source: '<index:><div class="box"></div>'
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view is="peanuts" />' +
+            '</div>' +
+          '<peanuts:>' +
+            '<div class="peanuts"></div>'
       };
-      var html = new ComponentHarness('<view is="box" />', Box).getHtml();
-      expect(html).equal('<div class="box"></div>');
+      var html = new ComponentHarness('<view is="box" />', Box).renderHtml().html;
+      expect(html).equal('<div class="box"><div class="peanuts"></div></div>');
+    });
+
+    it('renders child components', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view is="clown" />' +
+            '</div>'
+      };
+      function Clown() {}
+      Clown.view = {
+        is: 'clown',
+        source:
+          '<index:>' +
+            '<div class="clown"></div>'
+      };
+      var html = new ComponentHarness('<view is="box" />', Box, Clown).renderHtml().html;
+      expect(html).equal('<div class="box"><div class="clown"></div></div>');
+    });
+
+    it('creates child component instances', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view on-init="initClown()" is="clown" />' +
+            '</div>'
+      };
+      Box.prototype.initClown = function(clown) {
+        this.myClown = clown;
+      };
+      function Clown() {}
+      Clown.view = {
+        is: 'clown',
+        source:
+          '<index:>' +
+            '<div class="clown"></div>'
+      };
+      var box = new ComponentHarness('<view is="box" />', Box, Clown).renderHtml().component;
+      expect(box.myClown).instanceof(Clown);
     });
   });
 
-  describe('getFragment', function() {
+  describe('renderDom', function() {
     if (typeof document === 'undefined') return;
 
-    it('Returns a DocumentFragment', function() {
+    it('returns a page object', function() {
+      function Box() {}
+      Box.view = {is: 'box'};
+      var harness = new ComponentHarness('<view is="box" />', Box);
+      var page = harness.renderDom();
+      expect(page).instanceof(harness.app.Page);
+    });
+
+    it('sets component property on returned object', function() {
+      function Box() {}
+      Box.view = {is: 'box'};
+      var box = new ComponentHarness('<view is="box" />', Box).renderDom().component;
+      expect(box).instanceof(Box);
+    });
+
+    it('sets fragment property on returned object', function() {
       function Box() {}
       Box.view = {
         is: 'box',
         source: '<index:><div class="box"></div>'
       };
-      var fragment = new ComponentHarness('<view is="box" />', Box).getFragment();
+      var fragment = new ComponentHarness('<view is="box" />', Box).renderDom().fragment;
       expect(fragment).instanceof(DocumentFragment);
       expect(fragment).html('<div class="box"></div>');
+    });
+
+    it('creates child component instances', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view as="myClown" is="clown" />' +
+            '</div>'
+      };
+      function Clown() {}
+      Clown.view = {
+        is: 'clown',
+        source:
+          '<index:>' +
+            '<div class="clown"></div>'
+      };
+      var box = new ComponentHarness('<view is="box" />', Box, Clown).renderDom().component;
+      expect(box.myClown).instanceof(Clown);
     });
   });
 });

--- a/test/all/ComponentHarness.mocha.js
+++ b/test/all/ComponentHarness.mocha.js
@@ -155,6 +155,37 @@ describe('ComponentHarness', function() {
       var box = new ComponentHarness('<view is="box" />', Box, Clown).renderDom().component;
       expect(box.myClown).instanceof(Clown);
     });
+
+    it('will update fragments dynamically', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box {{if open}}open{{/if}}"></div>'
+      };
+      var page = new ComponentHarness('<view is="box" />', Box).renderDom();
+      var fragment = page.fragment;
+      var component = page.component;
+      expect(fragment).html('<div class="box "></div>');
+      component.model.set('open', true);
+      expect(fragment).html('<div class="box open"></div>');
+    });
+
+    it('will update nodes dynamically', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div as="container" class="box {{if open}}open{{/if}}"></div>'
+      };
+      var component = new ComponentHarness('<view is="box" />', Box).renderDom().component;
+      var container = component.container;
+      expect(container.className).equal('box ');
+      component.model.set('open', true);
+      expect(container.className).equal('box open');
+    });
   });
 
   describe('render assertion', function() {

--- a/test/all/ComponentHarness.mocha.js
+++ b/test/all/ComponentHarness.mocha.js
@@ -6,19 +6,19 @@ describe('ComponentHarness', function() {
   describe('getInstance', function() {
     it('creates a component instance', function() {
       function Box() {}
-      Box.is = 'box';
+      Box.view = {is: 'box'};
       var box = new ComponentHarness('<view is="box" />', Box).getInstance();
       expect(box).instanceof(Box);
     });
     it('Can pass a value to a component instance from harness template', function() {
       function Box() {}
-      Box.is = 'box';
+      Box.view = {is: 'box'};
       var box = new ComponentHarness('<view is="box" value="Hi" />', Box).getInstance();
       expect(box.model.get('value')).equal('Hi');
     });
     it('Can pass a value to a component instance from harness model', function() {
       function Box() {}
-      Box.is = 'box';
+      Box.view = {is: 'box'};
       var harness = new ComponentHarness('<view is="box" value="{{_page.message}}" />', Box);
       harness.model.set('_page.message', 'Yo.');
       var box = harness.getInstance();
@@ -29,8 +29,10 @@ describe('ComponentHarness', function() {
   describe('getHtml', function() {
     it('Returns HTML', function() {
       function Box() {}
-      Box.is = 'box';
-      Box.view = {source: '<div class="box"></div>'};
+      Box.view = {
+        is: 'box',
+        source: '<div class="box"></div>'
+      };
       var html = new ComponentHarness('<view is="box" />', Box).getHtml();
       expect(html).equal('<div class="box"></div>');
     });
@@ -41,8 +43,10 @@ describe('ComponentHarness', function() {
 
     it('Returns a DocumentFragment', function() {
       function Box() {}
-      Box.is = 'box';
-      Box.view = {source: '<div class="box"></div>'};
+      Box.view = {
+        is: 'box',
+        source: '<div class="box"></div>'
+      };
       var fragment = new ComponentHarness('<view is="box" />', Box).getFragment();
       expect(fragment).instanceof(DocumentFragment);
       expect(fragment).html('<div class="box"></div>');

--- a/test/all/ComponentHarness.mocha.js
+++ b/test/all/ComponentHarness.mocha.js
@@ -308,111 +308,7 @@ describe('ComponentHarness', function() {
     });
   });
 
-  describe('mock', function() {
-    it('defines an empty view and creates a property on page by name', function() {
-      function Box() {}
-      Box.view = {
-        is: 'box',
-        source:
-          '<index:>' +
-            '<div class="box">' +
-              '<view is="clown" expression="happy" />' +
-            '</div>'
-      };
-      var page = new ComponentHarness('<view is="box" />', Box)
-        .mock('clown').renderHtml();
-      expect(page.html).equal('<div class="box"></div>');
-      expect(page.clown.model.get('expression')).equal('happy');
-    });
-
-    it('supports as option', function() {
-      function Box() {}
-      Box.view = {
-        is: 'box',
-        source:
-          '<index:>' +
-            '<div class="box">' +
-              '<view is="clown" expression="happy" />' +
-            '</div>'
-      };
-      var page = new ComponentHarness('<view is="box" />', Box)
-        .mock({is: 'clown', as: 'myClown'}).renderHtml();
-      expect(page.html).equal('<div class="box"></div>');
-      expect(page.myClown.model.get('expression')).equal('happy');
-    });
-
-    it('supports asArray option', function() {
-      function Box() {}
-      Box.view = {
-        is: 'box',
-        source:
-          '<index:>' +
-            '<div class="box">' +
-              '<view is="clown" expression="happy" />' +
-              '<view is="clown" expression="sad" />' +
-            '</div>'
-      };
-      var page = new ComponentHarness('<view is="box" />', Box)
-        .mock({is: 'clown', asArray: 'clowns'}).renderHtml();
-      expect(page.html).equal('<div class="box"></div>');
-      expect(page.clowns.length).equal(2);
-      expect(page.clowns[0].model.get('expression')).equal('happy');
-      expect(page.clowns[1].model.get('expression')).equal('sad');
-    });
-
-    it('can be created via static createMock() method', function() {
-      function Box() {}
-      Box.view = {
-        is: 'box',
-        source:
-          '<index:>' +
-            '<div class="box">' +
-              '<view is="clown" expression="happy" />' +
-            '</div>'
-      };
-      var ClownMock = ComponentHarness.createMock({is: 'clown'});
-      var page = new ComponentHarness('<view is="box" />', Box, ClownMock).renderHtml();
-      expect(page.html).equal('<div class="box"></div>');
-      expect(page.clown.model.get('expression')).equal('happy');
-    });
-
-    it('can supply options to createMock() method', function() {
-      function Box() {}
-      Box.view = {
-        is: 'box',
-        source:
-          '<index:>' +
-            '<div class="box">' +
-              '<view is="clown" expression="happy" />' +
-            '</div>'
-      };
-      var ClownMock = ComponentHarness.createMock({is: 'clown', as: 'myClown'});
-      var page = new ComponentHarness('<view is="box" />', Box, ClownMock).renderHtml();
-      expect(page.html).equal('<div class="box"></div>');
-      expect(page.myClown.model.get('expression')).equal('happy');
-    });
-
-    it('can supply source to createMock() method', function() {
-      function Box() {}
-      Box.view = {
-        is: 'box',
-        source:
-          '<index:>' +
-            '<div class="box">' +
-              '<view is="clown" expression="happy" />' +
-            '</div>'
-      };
-      var ClownMock = ComponentHarness.createMock({
-        is: 'clown',
-        source: '<index:><div class="mock clown"></div>'
-      });
-      var page = new ComponentHarness('<view is="box" />', Box, ClownMock).renderHtml();
-      expect(page.html).equal('<div class="box"><div class="mock clown"></div></div>');
-      expect(page.clown.model.get('expression')).equal('happy');
-    });
-  });
-
-  describe('skip', function() {
+  describe('stub', function() {
     it('defines empty views by name', function() {
       function Box() {}
       Box.view = {
@@ -426,7 +322,7 @@ describe('ComponentHarness', function() {
             '</div>'
       };
       var html = new ComponentHarness('<view is="box" />', Box)
-        .skip('clown', 'ball', 'puppy').renderHtml().html;
+        .stub('clown', 'ball', 'puppy').renderHtml().html;
       expect(html).equal('<div class="box"></div>');
     });
 
@@ -448,8 +344,115 @@ describe('ComponentHarness', function() {
             '</div>',
         dependencies: [Clown]
       };
-      var html = new ComponentHarness('<view is="box" />', Box).skip('clown').renderHtml().html;
+      var html = new ComponentHarness('<view is="box" />', Box)
+        .stub('clown').renderHtml().html;
       expect(html).equal('<div class="box"></div>');
+    });
+  });
+
+  describe('stubComponent', function() {
+    it('defines an empty view and creates a property on page by name', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view is="clown" expression="happy" />' +
+              '<view is="ball" type="bouncy" />' +
+            '</div>'
+      };
+      var page = new ComponentHarness('<view is="box" />', Box)
+        .stubComponent('clown', 'ball').renderHtml();
+      expect(page.html).equal('<div class="box"></div>');
+      expect(page.clown.model.get('expression')).equal('happy');
+      expect(page.ball.model.get('type')).equal('bouncy');
+    });
+
+    it('supports `as` option', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view is="clown" expression="happy" />' +
+            '</div>'
+      };
+      var page = new ComponentHarness('<view is="box" />', Box)
+        .stubComponent({is: 'clown', as: 'myClown'}).renderHtml();
+      expect(page.html).equal('<div class="box"></div>');
+      expect(page.myClown.model.get('expression')).equal('happy');
+    });
+
+    it('supports `asArray` option', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view is="clown" expression="happy" />' +
+              '<view is="clown" expression="sad" />' +
+            '</div>'
+      };
+      var page = new ComponentHarness('<view is="box" />', Box)
+        .stubComponent({is: 'clown', asArray: 'clowns'}).renderHtml();
+      expect(page.html).equal('<div class="box"></div>');
+      expect(page.clowns.length).equal(2);
+      expect(page.clowns[0].model.get('expression')).equal('happy');
+      expect(page.clowns[1].model.get('expression')).equal('sad');
+    });
+
+    it('can be created via static createStubComponent() method', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view is="clown" expression="happy" />' +
+            '</div>'
+      };
+      var ClownStub = ComponentHarness.createStubComponent({is: 'clown'});
+      var page = new ComponentHarness('<view is="box" />', Box, ClownStub).renderHtml();
+      expect(page.html).equal('<div class="box"></div>');
+      expect(page.clown.model.get('expression')).equal('happy');
+    });
+
+    it('can supply options to createStubComponent() method', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view is="clown" expression="happy" />' +
+            '</div>'
+      };
+      var ClownStub = ComponentHarness.createStubComponent({is: 'clown', as: 'myClown'});
+      var page = new ComponentHarness('<view is="box" />', Box, ClownStub).renderHtml();
+      expect(page.html).equal('<div class="box"></div>');
+      expect(page.myClown.model.get('expression')).equal('happy');
+    });
+
+    it('can supply source to createStubComponent() method', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view is="clown" expression="happy" />' +
+            '</div>'
+      };
+      var ClownStub = ComponentHarness.createStubComponent({
+        is: 'clown',
+        source: '<index:><div class="stub clown"></div>'
+      });
+      var page = new ComponentHarness('<view is="box" />', Box, ClownStub).renderHtml();
+      expect(page.html).equal('<div class="box"><div class="stub clown"></div></div>');
+      expect(page.clown.model.get('expression')).equal('happy');
     });
   });
 });

--- a/test/browser/as.mocha.js
+++ b/test/browser/as.mocha.js
@@ -1,7 +1,5 @@
 var expect = require('chai').expect;
-var util = require('./util');
-var derby = util.derby;
-var expectHtml = util.expectHtml;
+var derby = require('./util').derby;
 
 describe('as', function() {
   it('HTML element `as` property', function() {
@@ -9,8 +7,8 @@ describe('as', function() {
     app.views.register('Body', '<div as="nested[0]"></div>');
     var page = app.createPage();
     var fragment = page.getFragment('Body');
-    expectHtml(page.nested[0], '<div></div>');
-    expectHtml(fragment, '<div></div>');
+    expect(page.nested[0]).html('<div></div>');
+    expect(fragment).html('<div></div>');
   });
 
   it('Component `as` property', function() {
@@ -22,8 +20,8 @@ describe('as', function() {
     var page = app.createPage();
     var fragment = page.getFragment('Body');
     expect(page.nested[0]).instanceof(Item);
-    expectHtml(page.nested[0].markerNode.nextSibling, '<div></div>');
-    expectHtml(fragment, '<div></div>');
+    expect(page.nested[0].markerNode.nextSibling).html('<div></div>');
+    expect(fragment).html('<div></div>');
   });
 
   it('HTML element `as-object` property', function() {
@@ -44,27 +42,27 @@ describe('as', function() {
     var fragment = page.getFragment('Body');
 
     expect(page.nested.map).all.keys('a', 'b', 'c');
-    expectHtml(page.nested.map.a, '<li>A</li>');
-    expectHtml(page.nested.map.b, '<li>B</li>');
-    expectHtml(page.nested.map.c, '<li>C</li>');
-    expectHtml(fragment, '<ul><li>A</li><li>B</li><li>C</li></ul>');
+    expect(page.nested.map.a).html('<li>A</li>');
+    expect(page.nested.map.b).html('<li>B</li>');
+    expect(page.nested.map.c).html('<li>C</li>');
+    expect(fragment).html('<ul><li>A</li><li>B</li><li>C</li></ul>');
 
     page.model.remove('_page.items', 1);
     expect(page.nested.map).all.keys('a', 'c');
-    expectHtml(page.nested.map.a, '<li>A</li>');
-    expectHtml(page.nested.map.c, '<li>C</li>');
-    expectHtml(fragment, '<ul><li>A</li><li>C</li></ul>');
+    expect(page.nested.map.a).html('<li>A</li>');
+    expect(page.nested.map.c).html('<li>C</li>');
+    expect(fragment).html('<ul><li>A</li><li>C</li></ul>');
 
     page.model.unshift('_page.items', {id: 'd', text: 'D'});
     expect(page.nested.map).all.keys('a', 'c', 'd');
-    expectHtml(page.nested.map.a, '<li>A</li>');
-    expectHtml(page.nested.map.c, '<li>C</li>');
-    expectHtml(page.nested.map.d, '<li>D</li>');
-    expectHtml(fragment, '<ul><li>D</li><li>A</li><li>C</li></ul>');
+    expect(page.nested.map.a).html('<li>A</li>');
+    expect(page.nested.map.c).html('<li>C</li>');
+    expect(page.nested.map.d).html('<li>D</li>');
+    expect(fragment).html('<ul><li>D</li><li>A</li><li>C</li></ul>');
 
     page.model.del('_page.items');
     expect(page.nested.map).eql({});
-    expectHtml(fragment, '<ul></ul>');
+    expect(fragment).html('<ul></ul>');
   });
 
   it('Component `as-object` property', function() {
@@ -93,32 +91,32 @@ describe('as', function() {
     expect(page.nested.map.a).instanceof(Item);
     expect(page.nested.map.b).instanceof(Item);
     expect(page.nested.map.c).instanceof(Item);
-    expectHtml(page.nested.map.a.markerNode.nextSibling, '<li>A</li>');
-    expectHtml(page.nested.map.b.markerNode.nextSibling, '<li>B</li>');
-    expectHtml(page.nested.map.c.markerNode.nextSibling, '<li>C</li>');
-    expectHtml(fragment, '<ul><li>A</li><li>B</li><li>C</li></ul>');
+    expect(page.nested.map.a.markerNode.nextSibling).html('<li>A</li>');
+    expect(page.nested.map.b.markerNode.nextSibling).html('<li>B</li>');
+    expect(page.nested.map.c.markerNode.nextSibling).html('<li>C</li>');
+    expect(fragment).html('<ul><li>A</li><li>B</li><li>C</li></ul>');
 
     page.model.remove('_page.items', 1);
     expect(page.nested.map).all.keys('a', 'c');
     expect(page.nested.map.a).instanceof(Item);
     expect(page.nested.map.c).instanceof(Item);
-    expectHtml(page.nested.map.a.markerNode.nextSibling, '<li>A</li>');
-    expectHtml(page.nested.map.c.markerNode.nextSibling, '<li>C</li>');
-    expectHtml(fragment, '<ul><li>A</li><li>C</li></ul>');
+    expect(page.nested.map.a.markerNode.nextSibling).html('<li>A</li>');
+    expect(page.nested.map.c.markerNode.nextSibling).html('<li>C</li>');
+    expect(fragment).html('<ul><li>A</li><li>C</li></ul>');
 
     page.model.unshift('_page.items', {id: 'd', text: 'D'});
     expect(page.nested.map).all.keys('a', 'c', 'd');
     expect(page.nested.map.a).instanceof(Item);
     expect(page.nested.map.c).instanceof(Item);
     expect(page.nested.map.d).instanceof(Item);
-    expectHtml(page.nested.map.a.markerNode.nextSibling, '<li>A</li>');
-    expectHtml(page.nested.map.c.markerNode.nextSibling, '<li>C</li>');
-    expectHtml(page.nested.map.d.markerNode.nextSibling, '<li>D</li>');
-    expectHtml(fragment, '<ul><li>D</li><li>A</li><li>C</li></ul>');
+    expect(page.nested.map.a.markerNode.nextSibling).html('<li>A</li>');
+    expect(page.nested.map.c.markerNode.nextSibling).html('<li>C</li>');
+    expect(page.nested.map.d.markerNode.nextSibling).html('<li>D</li>');
+    expect(fragment).html('<ul><li>D</li><li>A</li><li>C</li></ul>');
 
     page.model.del('_page.items');
     expect(page.nested.map).eql({});
-    expectHtml(fragment, '<ul></ul>');
+    expect(fragment).html('<ul></ul>');
   });
 
   it('HTML element `as-array` property', function() {
@@ -140,27 +138,27 @@ describe('as', function() {
 
     expect(page.nested.list).an('array');
     expect(page.nested.list).length(3);
-    expectHtml(page.nested.list[0], '<li>A</li>');
-    expectHtml(page.nested.list[1], '<li>B</li>');
-    expectHtml(page.nested.list[2], '<li>C</li>');
-    expectHtml(fragment, '<ul><li>A</li><li>B</li><li>C</li></ul>');
+    expect(page.nested.list[0]).html('<li>A</li>');
+    expect(page.nested.list[1]).html('<li>B</li>');
+    expect(page.nested.list[2]).html('<li>C</li>');
+    expect(fragment).html('<ul><li>A</li><li>B</li><li>C</li></ul>');
 
     page.model.remove('_page.items', 1);
     expect(page.nested.list).length(2);
-    expectHtml(page.nested.list[0], '<li>A</li>');
-    expectHtml(page.nested.list[1], '<li>C</li>');
-    expectHtml(fragment, '<ul><li>A</li><li>C</li></ul>');
+    expect(page.nested.list[0]).html('<li>A</li>');
+    expect(page.nested.list[1]).html('<li>C</li>');
+    expect(fragment).html('<ul><li>A</li><li>C</li></ul>');
 
     page.model.unshift('_page.items', {id: 'd', text: 'D'});
     expect(page.nested.list).length(3);
-    expectHtml(page.nested.list[0], '<li>D</li>');
-    expectHtml(page.nested.list[1], '<li>A</li>');
-    expectHtml(page.nested.list[2], '<li>C</li>');
-    expectHtml(fragment, '<ul><li>D</li><li>A</li><li>C</li></ul>');
+    expect(page.nested.list[0]).html('<li>D</li>');
+    expect(page.nested.list[1]).html('<li>A</li>');
+    expect(page.nested.list[2]).html('<li>C</li>');
+    expect(fragment).html('<ul><li>D</li><li>A</li><li>C</li></ul>');
 
     page.model.del('_page.items');
     expect(page.nested.list).eql([]);
-    expectHtml(fragment, '<ul></ul>');
+    expect(fragment).html('<ul></ul>');
   });
 
   it('Component `as-array` property', function() {
@@ -190,31 +188,31 @@ describe('as', function() {
     expect(page.nested.list[0]).instanceof(Item);
     expect(page.nested.list[1]).instanceof(Item);
     expect(page.nested.list[2]).instanceof(Item);
-    expectHtml(page.nested.list[0].markerNode.nextSibling, '<li>A</li>');
-    expectHtml(page.nested.list[1].markerNode.nextSibling, '<li>B</li>');
-    expectHtml(page.nested.list[2].markerNode.nextSibling, '<li>C</li>');
-    expectHtml(fragment, '<ul><li>A</li><li>B</li><li>C</li></ul>');
+    expect(page.nested.list[0].markerNode.nextSibling).html('<li>A</li>');
+    expect(page.nested.list[1].markerNode.nextSibling).html('<li>B</li>');
+    expect(page.nested.list[2].markerNode.nextSibling).html('<li>C</li>');
+    expect(fragment).html('<ul><li>A</li><li>B</li><li>C</li></ul>');
 
     page.model.remove('_page.items', 1);
     expect(page.nested.list).length(2);
     expect(page.nested.list[0]).instanceof(Item);
     expect(page.nested.list[1]).instanceof(Item);
-    expectHtml(page.nested.list[0].markerNode.nextSibling, '<li>A</li>');
-    expectHtml(page.nested.list[1].markerNode.nextSibling, '<li>C</li>');
-    expectHtml(fragment, '<ul><li>A</li><li>C</li></ul>');
+    expect(page.nested.list[0].markerNode.nextSibling).html('<li>A</li>');
+    expect(page.nested.list[1].markerNode.nextSibling).html('<li>C</li>');
+    expect(fragment).html('<ul><li>A</li><li>C</li></ul>');
 
     page.model.unshift('_page.items', {id: 'd', text: 'D'});
     expect(page.nested.list).length(3);
     expect(page.nested.list[0]).instanceof(Item);
     expect(page.nested.list[1]).instanceof(Item);
     expect(page.nested.list[2]).instanceof(Item);
-    expectHtml(page.nested.list[0].markerNode.nextSibling, '<li>D</li>');
-    expectHtml(page.nested.list[1].markerNode.nextSibling, '<li>A</li>');
-    expectHtml(page.nested.list[2].markerNode.nextSibling, '<li>C</li>');
-    expectHtml(fragment, '<ul><li>D</li><li>A</li><li>C</li></ul>');
+    expect(page.nested.list[0].markerNode.nextSibling).html('<li>D</li>');
+    expect(page.nested.list[1].markerNode.nextSibling).html('<li>A</li>');
+    expect(page.nested.list[2].markerNode.nextSibling).html('<li>C</li>');
+    expect(fragment).html('<ul><li>D</li><li>A</li><li>C</li></ul>');
 
     page.model.del('_page.items');
     expect(page.nested.list).eql([]);
-    expectHtml(fragment, '<ul></ul>');
+    expect(fragment).html('<ul></ul>');
   });
 });

--- a/test/browser/bindings.mocha.js
+++ b/test/browser/bindings.mocha.js
@@ -1,7 +1,5 @@
 var expect = require('chai').expect;
-var util = require('./util');
-var derby = util.derby;
-var expectHtml = util.expectHtml;
+var derby = require('./util').derby;
 
 describe('bindings', function() {
 
@@ -18,13 +16,13 @@ describe('bindings', function() {
       });
       key.set('one');
       var fragment = page.getFragment('Body');
-      expectHtml(fragment, 'hi');
+      expect(fragment).html('hi');
       key.set('two');
-      expectHtml(fragment, 'bye');
+      expect(fragment).html('bye');
       key.del();
-      expectHtml(fragment, '');
+      expect(fragment).html('');
       key.set('one');
-      expectHtml(fragment, 'hi');
+      expect(fragment).html('hi');
     });
 
     it('bracket outer dependency change', function() {
@@ -39,15 +37,15 @@ describe('bindings', function() {
       });
       key.set('one');
       var fragment = page.getFragment('Body');
-      expectHtml(fragment, 'hi');
+      expect(fragment).html('hi');
       doc.set('one', 'hello')
-      expectHtml(fragment, 'hello');
+      expect(fragment).html('hello');
       doc.set({
         one: 'heyo'
       });
-      expectHtml(fragment, 'heyo');
+      expect(fragment).html('heyo');
       doc.del();
-      expectHtml(fragment, '');
+      expect(fragment).html('');
     });
 
     it('bracket inner then outer dependency change', function() {
@@ -62,18 +60,18 @@ describe('bindings', function() {
       });
       key.set('one');
       var fragment = page.getFragment('Body');
-      expectHtml(fragment, 'hi');
+      expect(fragment).html('hi');
       key.set('two');
-      expectHtml(fragment, 'bye');
+      expect(fragment).html('bye');
       doc.set({
         one: 'heyo',
         two: 'later'
       });
-      expectHtml(fragment, 'later');
+      expect(fragment).html('later');
       doc.set('two', 'adios');
-      expectHtml(fragment, 'adios');
+      expect(fragment).html('adios');
       key.set('one');
-      expectHtml(fragment, 'heyo');
+      expect(fragment).html('heyo');
     });
   });
 
@@ -89,13 +87,13 @@ describe('bindings', function() {
       var view = page.model.at('_page.view');
       view.set('one');
       var fragment = page.getFragment('Body');
-      expectHtml(fragment, 'One');
+      expect(fragment).html('One');
       view.set('two');
-      expectHtml(fragment, 'Two');
+      expect(fragment).html('Two');
       view.del();
-      expectHtml(fragment, '');
+      expect(fragment).html('');
       view.set('one');
-      expectHtml(fragment, 'One');
+      expect(fragment).html('One');
     });
     it('bracketed dynamic view', function() {
       var app = derby.createApp();
@@ -110,17 +108,17 @@ describe('bindings', function() {
       var index = page.model.at('_page.index');
       index.set(0);
       var fragment = page.getFragment('Body');
-      expectHtml(fragment, 'One');
+      expect(fragment).html('One');
       index.set(1);
-      expectHtml(fragment, 'Two');
+      expect(fragment).html('Two');
       index.del();
-      expectHtml(fragment, '');
+      expect(fragment).html('');
       index.set(0);
-      expectHtml(fragment, 'One');
+      expect(fragment).html('One');
       page.model.set('_page.names', ['two', 'one']);
-      expectHtml(fragment, 'Two');
+      expect(fragment).html('Two');
       page.model.unshift('_page.names', 'three');
-      expectHtml(fragment, 'Three');
+      expect(fragment).html('Three');
     });
     it('only renders if the expression value changes', function() {
       var app = derby.createApp();
@@ -138,15 +136,15 @@ describe('bindings', function() {
       var view = page.model.at('_page.view');
       view.set('one');
       var fragment = page.getFragment('Body');
-      expectHtml(fragment, 'One 0');
+      expect(fragment).html('One 0');
       view.set('two');
-      expectHtml(fragment, 'Two 1');
+      expect(fragment).html('Two 1');
       view.set('TWO');
-      expectHtml(fragment, 'Two 1');
+      expect(fragment).html('Two 1');
       view.set('ONE');
-      expectHtml(fragment, 'One 2');
+      expect(fragment).html('One 2');
       view.set('one');
-      expectHtml(fragment, 'One 2');
+      expect(fragment).html('One 2');
     });
   });
 
@@ -162,14 +160,14 @@ describe('bindings', function() {
       );
       var page = app.createPage();
       var fragment = page.getFragment('Body');
-      expectHtml(fragment, 'otherwise');
+      expect(fragment).html('otherwise');
       var value = page.model.at('_page.nested.value');
       value.set(true);
-      expectHtml(fragment, 'true.');
+      expect(fragment).html('true.');
       value.set(false);
-      expectHtml(fragment, 'otherwise');
+      expect(fragment).html('otherwise');
       value.set('hello');
-      expectHtml(fragment, 'hello.');
+      expect(fragment).html('hello.');
     });
     it('unless', function() {
       var app = derby.createApp();
@@ -182,14 +180,14 @@ describe('bindings', function() {
       );
       var page = app.createPage();
       var fragment = page.getFragment('Body');
-      expectHtml(fragment, 'nada');
+      expect(fragment).html('nada');
       var value = page.model.at('_page.nested.value');
       value.set(true);
-      expectHtml(fragment, 'otherwise');
+      expect(fragment).html('otherwise');
       value.set(false);
-      expectHtml(fragment, 'nada');
+      expect(fragment).html('nada');
       value.set('hello');
-      expectHtml(fragment, 'otherwise');
+      expect(fragment).html('otherwise');
     });
     it('each else', function() {
       var app = derby.createApp();
@@ -202,18 +200,18 @@ describe('bindings', function() {
       );
       var page = app.createPage();
       var fragment = page.getFragment('Body');
-      expectHtml(fragment, 'otherwise');
+      expect(fragment).html('otherwise');
       var items = page.model.at('_page.items');
       items.set(['one', 'two', 'three']);
-      expectHtml(fragment, 'one.two.three.');
+      expect(fragment).html('one.two.three.');
       items.set([]);
-      expectHtml(fragment, 'otherwise');
+      expect(fragment).html('otherwise');
       items.insert(0, ['one', 'two', 'three']);
-      expectHtml(fragment, 'one.two.three.');
+      expect(fragment).html('one.two.three.');
       items.remove(0, 2);
-      expectHtml(fragment, 'three.');
+      expect(fragment).html('three.');
       items.remove(0, 1);
-      expectHtml(fragment, 'otherwise');
+      expect(fragment).html('otherwise');
     });
   });
 
@@ -234,7 +232,7 @@ describe('bindings', function() {
       items.set(['one', 'two', 'three']);
       toggle.set(true);
       items.move(2, 1);
-      expectHtml(fragment, 'one.three.two.');
+      expect(fragment).html('one.three.two.');
     });
   });
 
@@ -338,37 +336,37 @@ describe('bindings', function() {
       var page = app.createPage();
       var items = page.model.at('_page.items');
       var fragment = page.getFragment('Body');
-      expectHtml(fragment, '<ul></ul>');
+      expect(fragment).html('<ul></ul>');
       items.insert(0, itemData.slice(0, 2));
-      expectHtml(fragment,
+      expect(fragment).html(
         '<ul><li>0. One One</li><li>1. Two Two</li></ul>'
       );
       items.push(itemData[2]);
-      expectHtml(fragment,
+      expect(fragment).html(
         '<ul><li>0. One One</li><li>1. Two Two</li><li>2. Three Three</li></ul>'
       );
       items.unshift(itemData[3]);
-      expectHtml(fragment,
+      expect(fragment).html(
         '<ul><li>0. Four Four</li><li>1. One One</li><li>2. Two Two</li><li>3. Three Three</li></ul>'
       );
       items.remove(1, 2);
-      expectHtml(fragment,
+      expect(fragment).html(
         '<ul><li>0. Four Four</li><li>1. Three Three</li></ul>'
       );
       items.shift();
-      expectHtml(fragment,
+      expect(fragment).html(
         '<ul><li>0. Three Three</li></ul>'
       );
       items.pop();
-      expectHtml(fragment,
+      expect(fragment).html(
         '<ul></ul>'
       );
       items.pop();
-      expectHtml(fragment,
+      expect(fragment).html(
         '<ul></ul>'
       );
       items.push(itemData[0]);
-      expectHtml(fragment,
+      expect(fragment).html(
         '<ul><li>0. One One</li></ul>'
       );
     }
@@ -428,9 +426,9 @@ describe('bindings', function() {
     $items.set(['A']);
 
     var fragment = page.getFragment('Body');
-    expectHtml(fragment, '<ul><li>A</li></ul>');
+    expect(fragment).html('<ul><li>A</li></ul>');
     $items.insert(0, 'B');
-    expectHtml(fragment, '<ul><li>C</li><li>B</li><li>A</li></ul>');
+    expect(fragment).html('<ul><li>C</li><li>B</li><li>A</li></ul>');
   });
 
   it('mutation with number path segments', function() {
@@ -456,9 +454,9 @@ describe('bindings', function() {
     ]);
 
     var fragment = page.getFragment('Body');
-    expectHtml(fragment, '<ul><li>Red</li><li>Green</li><li>Blue</li></ul>');
+    expect(fragment).html('<ul><li>Red</li><li>Green</li><li>Blue</li></ul>');
     // Test mutation with a numeric path segment.
     app.model.set('_data.items.1.label', 'Verde');
-    expectHtml(fragment, '<ul><li>Red</li><li>Verde</li><li>Blue</li></ul>');
+    expect(fragment).html('<ul><li>Red</li><li>Verde</li><li>Blue</li></ul>');
   });
 });

--- a/test/browser/components.js
+++ b/test/browser/components.js
@@ -1,8 +1,6 @@
 var expect = require('chai').expect;
 var templates = require('derby-templates').templates;
-var util = require('./util');
-var derby = util.derby;
-var expectHtml = util.expectHtml;
+var derby = require('./util').derby;
 
 describe('components', function() {
 
@@ -86,7 +84,7 @@ describe('components', function() {
       };
       app.component('box', Box);
       var fragment = page.getFragment('Body');
-      expectHtml(fragment, '<div>120</div>');
+      expect(fragment).html('<div>120</div>');
     });
   });
 
@@ -401,9 +399,9 @@ describe('components', function() {
       this.Swatch = Swatch;
       this.app.component('swatch', Swatch);
       var fragment = this.page.getFragment('Body');
-      expectHtml(fragment, '<div style="background-color: blue"></div>');
+      expect(fragment).html('<div style="background-color: blue"></div>');
       this.page.model.set('_page.color', 'gray');
-      expectHtml(fragment, '<div style="background-color: gray"></div>');
+      expect(fragment).html('<div style="background-color: gray"></div>');
     });
 
     it('updates model when expression attribute changes', function() {
@@ -426,9 +424,9 @@ describe('components', function() {
       this.Swatch = Swatch;
       this.app.component('swatch', Swatch);
       var fragment = this.page.getFragment('Body');
-      expectHtml(fragment, 'lightblue<div style="background-color: lightblue"></div>');
+      expect(fragment).html('lightblue<div style="background-color: lightblue"></div>');
       this.page.model.set('_page.color', 'gray');
-      expectHtml(fragment, 'lightgray<div style="background-color: lightgray"></div>');
+      expect(fragment).html('lightgray<div style="background-color: lightgray"></div>');
     });
 
     it('updates model when template attribute changes', function() {
@@ -451,9 +449,9 @@ describe('components', function() {
       this.Swatch = Swatch;
       this.app.component('swatch', Swatch);
       var fragment = this.page.getFragment('Body');
-      expectHtml(fragment, 'lightblue<div style="background-color: lightblue"></div>');
+      expect(fragment).html('lightblue<div style="background-color: lightblue"></div>');
       this.page.model.set('_page.color', 'gray');
-      expectHtml(fragment, 'lightgray<div style="background-color: lightgray"></div>');
+      expect(fragment).html('lightgray<div style="background-color: lightgray"></div>');
     });
 
     it('updates view expression', function() {
@@ -480,11 +478,11 @@ describe('components', function() {
       this.Swatch = Swatch;
       this.app.component('swatch', Swatch);
       var fragment = this.page.getFragment('Body');
-      expectHtml(fragment, '<div style="background-color: lightblue">background-color: lightblue</div>');
+      expect(fragment).html('<div style="background-color: lightblue">background-color: lightblue</div>');
       this.page.model.set('_page.color', 'gray');
-      expectHtml(fragment, '<div style="background-color: lightgray">background-color: lightgray</div>');
+      expect(fragment).html('<div style="background-color: lightgray">background-color: lightgray</div>');
       this.page.model.set('_page.view', 'fore');
-      expectHtml(fragment, '<div style="color: lightgray">color: lightgray</div>');
+      expect(fragment).html('<div style="color: lightgray">color: lightgray</div>');
     });
 
     it('updates when template attribute is updated to new value inside component model', function() {
@@ -505,12 +503,12 @@ describe('components', function() {
       this.app.component('swatch', Swatch);
       var fragment = this.page.getFragment('Body');
       var swatch = this.page._components._1;
-      expectHtml(fragment, '<div style="background-color: lightblue">lightblue</div>');
+      expect(fragment).html('<div style="background-color: lightblue">lightblue</div>');
       var previous = swatch.model.set('value', 'gray');
-      expectHtml(fragment, '<div style="background-color: gray">gray</div>');
+      expect(fragment).html('<div style="background-color: gray">gray</div>');
       expect(this.page.model.get('_page.color')).equal('blue');
       swatch.model.set('value', previous);
-      expectHtml(fragment, '<div style="background-color: lightblue">lightblue</div>');
+      expect(fragment).html('<div style="background-color: lightblue">lightblue</div>');
     });
 
     it('renders template attribute passed through component and partial with correct context', function() {
@@ -541,7 +539,7 @@ describe('components', function() {
       this.app.component('picture-exhibit', PictureExhibit);
 
       var fragment = this.page.getFragment('Body');
-      expectHtml(fragment,
+      expect(fragment).html(
         '<div class="picture-frame">' +
           '<div style="background-color: blue">blue</div>' +
         '</div>' +
@@ -570,9 +568,9 @@ describe('components', function() {
       this.Swatch = Swatch;
       this.app.component('swatch', Swatch);
       var fragment = this.page.getFragment('Body');
-      expectHtml(fragment, '<div style="width: 10px; background-color: lightblue">lightblue</div>');
+      expect(fragment).html('<div style="width: 10px; background-color: lightblue">lightblue</div>');
       this.page.model.set('_page.color', 'green');
-      expectHtml(fragment, '<div style="width: 10px; background-color: lightgreen">lightgreen</div>');
+      expect(fragment).html('<div style="width: 10px; background-color: lightgreen">lightgreen</div>');
     });
 
     it('updates within template attribute', function() {
@@ -593,10 +591,10 @@ describe('components', function() {
       this.app.component('swatch', Swatch);
       var fragment = this.page.getFragment('Body');
       var swatch = this.page._components._1;
-      expectHtml(fragment, '<div>Hide me.</div>');
+      expect(fragment).html('<div>Hide me.</div>');
       expect(swatch.model.get('message')).instanceof(templates.Template);
       swatch.model.set('show', true);
-      expectHtml(fragment, '<div>Show me!</div>');
+      expect(fragment).html('<div>Show me!</div>');
       expect(swatch.model.get('message')).instanceof(templates.Template);
     });
 
@@ -618,10 +616,10 @@ describe('components', function() {
       this.app.component('swatch', Swatch);
       var fragment = this.page.getFragment('Body');
       var swatch = this.page._components._1;
-      expectHtml(fragment, '<div>Hide me.</div>');
+      expect(fragment).html('<div>Hide me.</div>');
       expect(swatch.model.get('message')).instanceof(templates.Template);
       swatch.model.set('show', true);
-      expectHtml(fragment, '<div>Show me!</div>');
+      expect(fragment).html('<div>Show me!</div>');
       expect(swatch.model.get('message')).instanceof(templates.Template);
     });
 
@@ -643,11 +641,11 @@ describe('components', function() {
       this.app.component('swatch', Swatch);
       var fragment = this.page.getFragment('Body');
       var swatch = this.page._components._1;
-      expectHtml(fragment, '<div>Hide me.</div>');
+      expect(fragment).html('<div>Hide me.</div>');
       expect(swatch.model.get('message')).instanceof(templates.Template);
       expect(swatch.getAttribute('message')).equal('Hide me.');
       swatch.model.set('show', true);
-      expectHtml(fragment, '<div>Show me!</div>');
+      expect(fragment).html('<div>Show me!</div>');
       // getAttribute works, but the rendering context is just inside the
       // component, so the alias is not defined
       expect(swatch.getAttribute('message')).equal('Hide me.');
@@ -667,11 +665,11 @@ describe('components', function() {
       this.app.component('swatch', Swatch);
       var fragment = this.page.getFragment('Body');
       var swatch = this.page._components._1;
-      expectHtml(fragment, '<div>Hide me.</div>');
+      expect(fragment).html('<div>Hide me.</div>');
       expect(swatch.model.get('message')).instanceof(templates.Template);
       expect(swatch.getAttribute('message')).equal('Hide me.');
       swatch.model.set('show', true);
-      expectHtml(fragment, '<div>Show me!</div>');
+      expect(fragment).html('<div>Show me!</div>');
       expect(swatch.getAttribute('message')).equal('Show me!');
     });
 
@@ -697,13 +695,13 @@ describe('components', function() {
       this.app.component('swatch', Swatch);
       var fragment = this.page.getFragment('Body');
       var swatch = this.page._components._1;
-      expectHtml(fragment, 'Hide me.Hide me.');
+      expect(fragment).html('Hide me.Hide me.');
       expect(swatch.getAttribute('items')).eql([
         {content: 'Hide me.'},
         {content: 'Hide me.'},
       ]);
       swatch.model.set('show', true);
-      expectHtml(fragment, 'Show me!Hide me.');
+      expect(fragment).html('Show me!Hide me.');
       expect(swatch.getAttribute('items')).eql([
         {content: 'Hide me.'},
         {content: 'Hide me.'},
@@ -734,13 +732,13 @@ describe('components', function() {
       this.app.component('swatch', Swatch);
       var fragment = this.page.getFragment('Body');
       var swatch = this.page._components._1;
-      expectHtml(fragment, 'Hide me.Hide me.');
+      expect(fragment).html('Hide me.Hide me.');
       expect(swatch.getAttribute('items')).eql([
         {content: 'Hide me.'},
         {content: 'Hide me.'},
       ]);
       swatch.model.set('show', true);
-      expectHtml(fragment, 'Show me!Hide me.');
+      expect(fragment).html('Show me!Hide me.');
       expect(swatch.getAttribute('items')).eql([
         {content: 'Hide me.'},
         {content: 'Hide me.'},
@@ -769,12 +767,12 @@ describe('components', function() {
       this.app.component('swatch', Swatch);
       var fragment = this.page.getFragment('Body');
       var swatch = this.page._components._1;
-      expectHtml(fragment, 'Hide me.Hide me.');
+      expect(fragment).html('Hide me.Hide me.');
       expect(swatch.model.get('items').length).equal(2);
       expect(swatch.model.get('items')[0].content).instanceof(templates.Template);
       expect(swatch.model.get('items')[1].content).instanceof(templates.Template);
       swatch.model.set('show', true);
-      expectHtml(fragment, 'Show me!Hide me.');
+      expect(fragment).html('Show me!Hide me.');
     });
 
     it('updates array within template attribute in model from partial', function() {
@@ -802,12 +800,12 @@ describe('components', function() {
       this.app.component('swatch', Swatch);
       var fragment = this.page.getFragment('Body');
       var swatch = this.page._components._1;
-      expectHtml(fragment, 'Hide me.Hide me.');
+      expect(fragment).html('Hide me.Hide me.');
       expect(swatch.model.get('items').length).equal(2);
       expect(swatch.model.get('items')[0].content).instanceof(templates.Template);
       expect(swatch.model.get('items')[1].content).instanceof(templates.Template);
       swatch.model.set('show', true);
-      expectHtml(fragment, 'Show me!Hide me.');
+      expect(fragment).html('Show me!Hide me.');
     });
 
     it('updates array within attribute bound to component model path', function() {
@@ -830,13 +828,13 @@ describe('components', function() {
       this.app.component('swatch', Swatch);
       var fragment = this.page.getFragment('Body');
       var swatch = this.page._components._1;
-      expectHtml(fragment, 'Hide me.Hide me.');
+      expect(fragment).html('Hide me.Hide me.');
       expect(swatch.getAttribute('items')).eql([
         {content: 'Hide me.'},
         {content: 'Hide me.'},
       ]);
       swatch.model.set('show', true);
-      expectHtml(fragment, 'Show me!Hide me.');
+      expect(fragment).html('Show me!Hide me.');
       expect(swatch.getAttribute('items')).eql([
         {content: 'Show me!'},
         {content: 'Hide me.'},
@@ -865,12 +863,12 @@ describe('components', function() {
       this.app.component('swatch', Swatch);
       var fragment = this.page.getFragment('Body');
       var swatch = this.page._components._1;
-      expectHtml(fragment, 'Hide me.Hide me.');
+      expect(fragment).html('Hide me.Hide me.');
       expect(swatch.model.get('items').length).equal(2);
       expect(swatch.model.get('items')[0].content).instanceof(templates.Template);
       expect(swatch.model.get('items')[1].content).equal('Hide me.')
       swatch.model.set('show', true);
-      expectHtml(fragment, 'Show me!Hide me.');
+      expect(fragment).html('Show me!Hide me.');
     });
 
   });

--- a/test/browser/dom-events.mocha.js
+++ b/test/browser/dom-events.mocha.js
@@ -1,7 +1,5 @@
 var expect = require('chai').expect;
-var util = require('./util');
-var derby = util.derby;
-var expectHtml = util.expectHtml;
+var derby = require('./util').derby;
 
 describe('DOM events', function() {
   it('HTML element markup custom `create` event', function() {
@@ -20,9 +18,9 @@ describe('DOM events', function() {
       span = element;
     };
     var fragment = page.getFragment('Body');
-    expectHtml(fragment, '<div><span></span></div>');
-    expectHtml(div, '<div><span></span></div>');
-    expectHtml(span, '<span></span>');
+    expect(fragment).html('<div><span></span></div>');
+    expect(div).html('<div><span></span></div>');
+    expect(span).html('<span></span>');
   });
 
   it('HTML element markup custom `destroy` event', function() {
@@ -40,12 +38,12 @@ describe('DOM events', function() {
       span = element;
     };
     var fragment = page.getFragment('Body');
-    expectHtml(fragment, '<div><span></span></div>');
+    expect(fragment).html('<div><span></span></div>');
     expect(span).equal(undefined);
 
     page.model.set('_page.hide', true);
-    expectHtml(fragment, '<div></div>');
-    expectHtml(span, '<span></span>');
+    expect(fragment).html('<div></div>');
+    expect(span).html('<span></span>');
   });
 
   it('dom.on custom `destroy` event', function() {
@@ -63,11 +61,11 @@ describe('DOM events', function() {
     page.dom.on('destroy', page.span, function() {
       destroyed = true;
     });
-    expectHtml(fragment, '<div><span></span></div>');
+    expect(fragment).html('<div><span></span></div>');
     expect(destroyed).equal(false);
 
     page.model.set('_page.hide', true);
-    expectHtml(fragment, '<div></div>');
+    expect(fragment).html('<div></div>');
     expect(destroyed).equal(true);
   });
 });

--- a/test/browser/forms.js
+++ b/test/browser/forms.js
@@ -1,7 +1,5 @@
 var expect = require('chai').expect;
-var util = require('./util');
-var derby = util.derby;
-var expectHtml = util.expectHtml;
+var derby = require('./util').derby;
 
 describe('forms', function() {
 
@@ -22,7 +20,7 @@ describe('forms', function() {
       var text = page.model.at('_page.text');
       text.set('Hi');
       var fragment = page.getFragment('Body');
-      expectHtml(fragment, '<textarea>Hi</textarea>');
+      expect(fragment).html('<textarea>Hi</textarea>');
       var textarea = fragment.firstChild;
       expect(textarea.value).equal('Hi');
       var textNode = textarea.firstChild;

--- a/test/browser/util.js
+++ b/test/browser/util.js
@@ -1,28 +1,6 @@
-var expect = require('chai').expect;
+var chai = require('chai');
 var DerbyStandalone = require('../../lib/DerbyStandalone');
-var derby = new DerbyStandalone();
 require('derby-parsing');
+require('../../test-utils').assertions(window, chai.Assertion);
 
-exports.derby = derby;
-exports.expectHtml = expectHtml;
-exports.fragmentHtml = fragmentHtml;
-
-function expectHtml(fragment, html) {
-  expect(fragmentHtml(fragment)).equal(html);
-}
-
-function fragmentHtml(fragment) {
-  var clone = document.importNode(fragment, true);
-  // last two arguments for createTreeWalker are required in IE unfortunately
-  var treeWalker = document.createTreeWalker(clone, NodeFilter.SHOW_COMMENT, null, false);
-  var toRemove = [];
-  for (var node; node = treeWalker.nextNode();) {
-    toRemove.push(node);
-  }
-  for (var i = toRemove.length; i--;) {
-    toRemove[i].parentNode.removeChild(toRemove[i]);
-  }
-  var el = document.createElement('ins');
-  el.appendChild(clone);
-  return el.innerHTML;
-}
+exports.derby = new DerbyStandalone();


### PR DESCRIPTION
# Changes

1. This PR adds a new preferred format for specifying the view associated with a component with an object. (See below for examples.) The goal is to allow the view of a component to be inlined in JavaScript as a string, primarily for mocking components in tests. Use of inline view source is discouraged in production application code, which should use external files for views.

Examples:
```js
class Box {
  static view = {file: __dirname};
}
```

```js
class Box {
  static view = {
    is: 'box',
    file: __dirname
  };
}
```

```js
class Box {
  static view = {
    is: 'box',
    source: `
      <index: attributes="foo bar">
        <div class="box">
          {{@content}}
        </div>`
  };
}
```

2. Components can now specify their dependencies on other components! Now, calling `app.component()` will recursively register other components needed for the parent component.

```js
class Box {
  static view = {
    is: 'box',
    file: __dirname,
    dependencies: [
      require('../clown'),
      require('../ball')
    ]
  };
}
```

3. This PR also introduces `derby/test-utils`, which will be used to provide utilities for component unit tests initially. This PR implements ComponentHarness, which can be used to render a standalone component as HTML or with a DOM. It also implements the `html` and `render` Chai assertions. `html()` is very handy for writing assertions for the content of a document fragment or DOM node in HTML. `render()` is used to test that a harness will render successfully as HTML, DOM, and attaching (as is done on page load from a server render).