### PR TITLE
Commented excessive server notification on connection

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -325,11 +325,17 @@ App.prototype._autoRefresh = function() {
   var app = this;
   var connection = this.model.connection;
   connection.on('connected', function() {
+    // Do we need to send such message to the server?
+    // Cause `sharedb` does not understand such received data.
+    // and throwns an error `{code: 4000, message: 'Invalid or unknown message'}`.
+    // Actual for non-production environment
+    /*
     connection.send({
       derby: 'app',
       name: app.name,
       hash: app.scriptHash
     });
+    */
   });
   connection.on('receive', function(request) {
     if (request.data.derby) {


### PR DESCRIPTION
Do not send message from the client to the server after successful connection.
Actual for development environment.

Example of error on the server side:
`
2019-11-17 23:21:27Z Remote Client -> Backend 84bd1ec4a82fe3b2b0058e7c810498a6 
2019-11-17 23:21:27Z Backend -> Remote Client 84bd1ec4a82fe3b2b0058e7c810498a6 Error: {
  derby: 'app',
  name: 'Live,
  hash: '3d78d75af57f1222698251167606eff0',
  error: { code: 4000, message: 'Invalid or unknown message' }
} `

Example of error on the client side (as initiator):
![Screenshot from 2019-11-18 01-26-13](https://user-images.githubusercontent.com/5160609/69015990-b2f56500-09a2-11ea-9ef3-f69879489fe3.png)
