### PR TITLE
ComponentHarness: Fake implementations of app.history #push and #replace

### DIFF
--- a/test-utils/ComponentHarness.js
+++ b/test-utils/ComponentHarness.js
@@ -148,11 +148,20 @@ ComponentHarness.prototype._get = function(render, options) {
   var page = this.app.createPage();
   // Set `page.params`, which is usually created in tracks during `Page#render`:
   // https://github.com/derbyjs/tracks/blob/master/lib/index.js
-  page.params = {
-    url: url,
-    query: qs.parse(urlParse(url).query),
-    body: {},
-  };
+  function setPageUrl(url) {
+    page.params = {
+      url: url,
+      query: qs.parse(urlParse(url).query),
+      body: {},
+    };
+    // Set "$render.params", "$render.query", "$render.url" based on `page.params`.
+    page._setRenderParams();
+  }
+  setPageUrl(url);
+  // Fake some methods from tracks/lib/History.js.
+  // JSDOM doesn't really support updating the window URL, but this should work for Derby code that
+  // pulls URL info from the model or page.
+  this.app.history = { push: setPageUrl, replace: setPageUrl };
 
   render(page);
   // HACK: Implement getting an instance as a side-effect of rendering. This

--- a/test/dom/ComponentHarness.mocha.js
+++ b/test/dom/ComponentHarness.mocha.js
@@ -197,4 +197,48 @@ describe('ComponentHarness', function() {
       expect(harness).to.render('');
     });
   });
+
+  describe.only('fake app.history implementation', function() {
+    it('accepts url option', function() {
+      var renderUrl = '/box?size=123';
+      var expectedQueryParams = {size: '123'};
+
+      var harness = runner.createHarness(
+        'url: {{$render.url}} | query: {{JSON.stringify($render.query)}}'
+      );
+      var expectedHtml = 'url: /box?size=123 | query: {"size":"123"}';
+
+      var page = harness.renderHtml({url: renderUrl});
+      expectPageParams(page, renderUrl, expectedQueryParams);
+      expect(page.html).to.equal(expectedHtml);
+
+      page = harness.renderDom({url: renderUrl});
+      expectPageParams(page, renderUrl, expectedQueryParams);
+      expect(page.fragment).html(expectedHtml);
+    });
+
+    it('supports push(url) and replace(url)', function() {
+      var harness = runner.createHarness(
+        'url: {{$render.url}} | query: {{JSON.stringify($render.query)}}'
+      );
+
+      var page = harness.renderDom();
+      expectPageParams(page, '', {});
+
+      var newUrl = '/box?size=123';
+      harness.app.history.push(newUrl);
+      expectPageParams(page, newUrl, {size: '123'});
+      expect(page.fragment).html('url: /box?size=123 | query: {"size":"123"}');
+
+      newUrl = '/sphere?radius=456';
+      harness.app.history.replace(newUrl);
+      expectPageParams(page, newUrl, {radius: '456'});
+      expect(page.fragment).html('url: /sphere?radius=456 | query: {"radius":"456"}');
+    });
+  });
 });
+
+function expectPageParams(page, expectedUrl, expectedQuery) {
+  expect(page).to.have.property('params')
+    .that.deep.includes({url: expectedUrl, query: expectedQuery});
+}


### PR DESCRIPTION
JSDOM doesn't support window navigation, but thankfully Derby apps often use Derby's routing, which is in tracks.

That means we can fake out `app.history` in the ComponentHarness. This PR specifically adds fakes for `app.history.push(url)` and `app.history.replace(url)`, which are usually defined in https://github.com/derbyjs/tracks/blob/v0.5.8/lib/History.js