### PR TITLE
fix #571 - don't check component dependency override when deserializing

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -235,7 +235,7 @@ App.prototype.component = function(name, constructor, isDependency) {
 
   // Calling app.component() overrides existing views or components. Prevent
   // dependencies from doing this without warning
-  if (isDependency && currentView) {
+  if (isDependency && currentView && !serializedViews) {
     throw new Error('Dependencies cannot override existing views. Already registered "' + viewName + '"');
   }
 


### PR DESCRIPTION
Quick fix for issue #571. Not sure if there is a more elegant way to do this, but this seems to work well.