### PR TITLE
Stub with source

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -235,7 +235,7 @@ App.prototype.component = function(name, constructor, isDependency) {
 
   // Calling app.component() overrides existing views or components. Prevent
   // dependencies from doing this without warning
-  if (isDependency && currentView && !serializedViews) {
+  if (isDependency && currentView && typeof serializedViews !== 'function') {
     throw new Error('Dependencies cannot override existing views. Already registered "' + viewName + '"');
   }
 

--- a/lib/App.js
+++ b/lib/App.js
@@ -235,7 +235,7 @@ App.prototype.component = function(name, constructor, isDependency) {
 
   // Calling app.component() overrides existing views or components. Prevent
   // dependencies from doing this without warning
-  if (isDependency && currentView && typeof serializedViews !== 'function') {
+  if (isDependency && currentView && !currentView.fromSerialized) {
     throw new Error('Dependencies cannot override existing views. Already registered "' + viewName + '"');
   }
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "chokidar": "^3.1.1",
     "derby-parsing": "^0.7.6",
-    "derby-templates": "^0.7.3",
+    "derby-templates": "^0.7.4",
     "html-util": "^0.2.1",
     "qs": "^6.0.2",
     "racer": "^0.9.0",

--- a/test-utils/ComponentHarness.js
+++ b/test-utils/ComponentHarness.js
@@ -70,18 +70,21 @@ ComponentHarness.prototype.setup = function(source) {
  * A view name is a colon-separated string of segments, as used in `<view is="...">`.
  *
  * @example
- *   var harness = new ComponentHarness('<view is="dialog"/>', Dialog)
- *     .stub('icons:open-icon', 'icons:close-icon');
+ *   var harness = new ComponentHarness('<view is="dialog"/>', Dialog).stub(
+ *     'icons:open-icon',
+ *     'icons:close-icon',
+ *     {is: 'dialog:buttons', source: '<button>OK</button>'}
+ *   );
  */
 ComponentHarness.prototype.stub = function() {
   for (var i = 0; i < arguments.length; i++) {
     var arg = arguments[i];
     if (typeof arg === 'string') {
       this.app.views.register(arg, '');
-    } else if (Array.isArray(arg)) {
-      this.app.views.register(arg[0], arg[1] || '');
+    } else if (arg && arg.is) {
+      this.app.views.register(arg.is, arg.source || '');
     } else {
-      throw new Error('each argument must be a view name string or an array of [name, source]');
+      throw new Error('each argument must be the name of a view or an object with an `is` property');
     }
   }
   return this;

--- a/test-utils/ComponentHarness.js
+++ b/test-utils/ComponentHarness.js
@@ -65,7 +65,7 @@ ComponentHarness.prototype.setup = function(source) {
 };
 
 /**
- * Stubs out view names with empty views.
+ * Stubs out view names with empty view or the provided source.
  *
  * A view name is a colon-separated string of segments, as used in `<view is="...">`.
  *
@@ -75,8 +75,14 @@ ComponentHarness.prototype.setup = function(source) {
  */
 ComponentHarness.prototype.stub = function() {
   for (var i = 0; i < arguments.length; i++) {
-    var name = arguments[i];
-    this.app.views.register(name, '');
+    var arg = arguments[i];
+    if (typeof arg === 'string') {
+      this.app.views.register(arg, '');
+    } else if (Array.isArray(arg)) {
+      this.app.views.register(arg[0], arg[1] || '');
+    } else {
+      throw new Error('each argument must be a view name string or an array of [name, source]');
+    }
   }
   return this;
 };

--- a/test/all/ComponentHarness.mocha.js
+++ b/test/all/ComponentHarness.mocha.js
@@ -1,5 +1,6 @@
 var expect = require('chai').expect;
 var ComponentHarness = require('../../test-utils').ComponentHarness;
+var derbyTemplates = require('../../templates');
 
 describe('ComponentHarness', function() {
   describe('renderHtml', function() {
@@ -214,6 +215,46 @@ describe('ComponentHarness', function() {
       expect(function() {
         new ComponentHarness('<view is="box" />', ConflictingClown, Box);
       }).to.throw(Error);
+    });
+
+    it('supports view serializing', function() {
+      function Clown() {}
+      Clown.view = {
+        is: 'clown',
+        source:
+          '<index:>' +
+            '<div class="{{getClass()}}"></div>'
+      };
+      Clown.prototype.getClass = function() {
+        return 'clown';
+      };
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="{{getClass()}}">' +
+              '<view is="clown" />' +
+            '</div>',
+        dependencies: [Clown]
+      };
+      Box.prototype.getClass = function() {
+        return 'box';
+      };
+      var harness = new ComponentHarness('<view is="box" />', Box);
+      // Serialize returns JavaScript source code that is written to and
+      // required from a file. We simulate that by evaling the source
+      var serializedSource = harness.app.views.serialize();
+      var serialized = (new Function('return ' + serializedSource))();
+
+      // This is similar to what would happen in the browser. Derby would inject
+      // the serialized views, then the application code would execute and
+      // associate the views with component controllers
+      var harness2 = new ComponentHarness();
+      serialized(derbyTemplates, harness2.app.views);
+      harness2.app.component(Box);
+      var html = harness2.renderHtml().html;
+      expect(html).equal('<div class="box"><div class="clown"></div></div>');
     });
 
     it('gets overridden without error', function() {

--- a/test/all/ComponentHarness.mocha.js
+++ b/test/all/ComponentHarness.mocha.js
@@ -393,7 +393,7 @@ describe('ComponentHarness', function() {
       expect(html).equal('<div class="box"></div>');
     });
 
-    it('defines non-empty views with array arguments', function() {
+    it('defines source of view when provided', function() {
       function Box() {}
       Box.view = {
         is: 'box',
@@ -408,10 +408,17 @@ describe('ComponentHarness', function() {
       var html = new ComponentHarness('<view is="box" />', Box)
         .stub(
           'clown',
-          ['ball', '<span class="ball"></span>'],
+          {is: 'ball', source: '<span class="ball"></span>'},
           'puppy'
         ).renderHtml().html;
       expect(html).equal('<div class="box"><span class="ball"></span></div>');
+    });
+
+    it('throws error if no view name is provided', function() {
+      var harness = new ComponentHarness('');
+      expect(function() {
+        harness.stub({source: '<div></div>'});
+      }).to.throw(Error);
     });
 
     it('overrides a component dependency with an empty view', function() {

--- a/test/all/ComponentHarness.mocha.js
+++ b/test/all/ComponentHarness.mocha.js
@@ -352,6 +352,27 @@ describe('ComponentHarness', function() {
       expect(html).equal('<div class="box"></div>');
     });
 
+    it('defines non-empty views with array arguments', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source:
+          '<index:>' +
+            '<div class="box">' +
+              '<view is="clown" />' +
+              '<view is="ball" />' +
+              '<view is="puppy" />' +
+            '</div>'
+      };
+      var html = new ComponentHarness('<view is="box" />', Box)
+        .stub(
+          'clown',
+          ['ball', '<span class="ball"></span>'],
+          'puppy'
+        ).renderHtml().html;
+      expect(html).equal('<div class="box"><span class="ball"></span></div>');
+    });
+
     it('overrides a component dependency with an empty view', function() {
       function Clown() {}
       Clown.view = {


### PR DESCRIPTION
add support for passing view source to harness.stub()
use the array of name and source, which is analogous to the syntax of component dependencies