### PR TITLE
docs: Fix simple typo, workaroud -> workaround

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -434,7 +434,7 @@ var _extendComponent = (Object.setPrototypeOf && Object.getPrototypeOf) ?
     // Find the end of the prototype chain
     var rootPrototype = getRootPrototype(constructor.prototype);
 
-    // This guard is a workaroud to a bug that has occurred in Chakra when
+    // This guard is a workaround to a bug that has occurred in Chakra when
     // app.component() is invoked twice on the same constructor. In that case,
     // the `instanceof Component` check in extendComponent incorrectly returns
     // false after the prototype has already been set to `Component.prototype`.


### PR DESCRIPTION
There is a small typo in lib/components.js.

Should read `workaround` rather than `workaroud`.

