### PR TITLE
Improve test-utils assertions

### DIFF
--- a/test-utils/assertions.js
+++ b/test-utils/assertions.js
@@ -56,8 +56,8 @@ module.exports = function(dom, Assertion) {
 
       this.assert(
         html === expected,
-        'expected the HTML #{exp} but got #{act}',
-        'expected to not have HTML #{act}',
+        'expected DOM rendering to produce the HTML #{exp} but got #{act}',
+        'expected DOM rendering to not produce actual HTML #{act}',
         expected,
         html
       );
@@ -80,7 +80,7 @@ module.exports = function(dom, Assertion) {
       // test that all modes of rendering will be equivalent
       if (expected == null) expected = html;
       new Assertion(expected).is.a('string');
-      new Assertion(html).equal(expected);
+      new Assertion(html).equal(expected, 'HTML string rendering does not match expected HTML');
 
       // Check DOM rendering is also equivalent
       var fragment = harness.renderDom(options).fragment;

--- a/test-utils/assertions.js
+++ b/test-utils/assertions.js
@@ -82,9 +82,13 @@ module.exports = function(dom, Assertion) {
       new Assertion(expected).is.a('string');
       new Assertion(html).equal(expected, 'HTML string rendering does not match expected HTML');
 
-      // Check DOM rendering is also equivalent
-      var fragment = harness.renderDom(options).fragment;
-      new Assertion(fragment).html(expected, options);
+      // Check DOM rendering is also equivalent.
+      // This uses the harness "pageRendered" event to grab the rendered DOM *before* any component
+      // `create()` methods are called, as `create()` methods can do DOM mutations.
+      harness.once('pageRendered', function(page) {
+        new Assertion(page.fragment).html(expected, options);
+      });
+      harness.renderDom(options);
 
       // Try attaching. Attachment will throw an error if HTML doesn't match
       var el = domDocument.createElement(parentTag);

--- a/test/dom/ComponentHarness.mocha.js
+++ b/test/dom/ComponentHarness.mocha.js
@@ -204,7 +204,7 @@ describe('ComponentHarness', function() {
         source: '<index:><div class="box" as="boxElement"></div>'
       };
       Box.prototype.create = function() {
-        this.boxElement.className = 'box2';
+        this.boxElement.className = 'box-changed-in-create';
       };
       var harness = runner.createHarness('<view is="box" />', Box);
       expect(harness).to.render('<div class="box"></div>');

--- a/test/dom/ComponentHarness.mocha.js
+++ b/test/dom/ComponentHarness.mocha.js
@@ -196,6 +196,19 @@ describe('ComponentHarness', function() {
       var harness = runner.createHarness('<view is="box" />', Box);
       expect(harness).to.render('');
     });
+
+    it('ignores DOM mutations in components\' create()', function() {
+      function Box() {}
+      Box.view = {
+        is: 'box',
+        source: '<index:><div class="box" as="boxElement"></div>'
+      };
+      Box.prototype.create = function() {
+        this.boxElement.className = 'box2';
+      };
+      var harness = runner.createHarness('<view is="box" />', Box);
+      expect(harness).to.render('<div class="box"></div>');
+    });
   });
 
   describe('fake app.history implementation', function() {

--- a/test/dom/ComponentHarness.mocha.js
+++ b/test/dom/ComponentHarness.mocha.js
@@ -209,6 +209,12 @@ describe('ComponentHarness', function() {
       var harness = runner.createHarness('<view is="box" />', Box);
       expect(harness).to.render('<div class="box"></div>');
     });
+
+    it('works with HTML entities like &nbsp;', function() {
+      var harness = runner.createHarness('&lt;&nbsp;&quot;&gt;');
+      expect(harness).to.render();
+      expect(harness).to.render('&lt;&nbsp;"&gt;');
+    });
   });
 
   describe('fake app.history implementation', function() {


### PR DESCRIPTION
* In failure messages, state whether it was the HTML or DOM rendering that failed.
    - This makes it easier to debug test failures.
* `.to.render()` - Compare DOM rendering to the HTML before components' `create()` methods are called.
    - This fixes an issue where the assertion was improperly failing when a component modified its DOM in `create()`.
* Normalize HTML before comparisons.
    - This fixes an issue where `.to.render()` assertions would fail when templates used HTML entities like `&nbsp;`.
