### PR TITLE
Fix Component#destroy error when no bindings exist, update test-utils to call Page#destroy

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -53,8 +53,10 @@ Component.prototype.destroy = function() {
   this.model.removeContextListeners();
   this.model.destroy();
   delete this.page._components[this.id];
-  var components = this.page._eventModel.object.$components;
-  if (components) delete components.object[this.id];
+  if (this.page._eventModel.object) {
+    var components = this.page._eventModel.object.$components;
+    if (components) delete components.object[this.id];
+  }
   this.isDestroyed = true;
 };
 

--- a/test-utils/ComponentHarness.js
+++ b/test-utils/ComponentHarness.js
@@ -9,16 +9,14 @@ var AppForServer = require('../lib/AppForServer');
 function AppForHarness(harness) {
   App.call(this);
   this._harness = harness;
+  this._pages = [];
 }
 AppForHarness.prototype = Object.create(App.prototype);
 AppForHarness.prototype.constructor = AppForHarness;
 
 AppForHarness.prototype.createPage = function() {
-  if (this.page) {
-    this.page.destroy();
-  }
   var page = new this.Page(this, this._harness.model);
-  this.page = page;
+  this._pages.push(page);
   return page;
 };
 

--- a/test-utils/ComponentHarness.js
+++ b/test-utils/ComponentHarness.js
@@ -14,7 +14,12 @@ AppForHarness.prototype = Object.create(App.prototype);
 AppForHarness.prototype.constructor = AppForHarness;
 
 AppForHarness.prototype.createPage = function() {
-  return new this.Page(this, this._harness.model);
+  if (this.page) {
+    this.page.destroy();
+  }
+  var page = new this.Page(this, this._harness.model);
+  this.page = page;
+  return page;
 };
 
 // Load views by filename. The client version of this method is a no-op

--- a/test-utils/domTestRunner.js
+++ b/test-utils/domTestRunner.js
@@ -15,6 +15,7 @@ exports.DomTestRunner = DomTestRunner;
 function DomTestRunner() {
   this.window = null;
   this.document = null;
+  this.harnesses = [];
 }
 
 DomTestRunner.prototype.installMochaHooks = function(options) {
@@ -36,7 +37,7 @@ DomTestRunner.prototype.createHarness = function() {
   if (arguments.length > 0) {
     harness.setup.apply(harness, arguments);
   }
-  runner._harness = harness;
+  this.harnesses.push(harness);
   return harness;
 };
 
@@ -64,12 +65,12 @@ function mochaHooksForNode(runner, options) {
   global.afterEach(function() {
     // Destroy the pages created by the harness, so that if a test cleans up its model itself,
     // bindings won't throw errors due to `document` not being present.
-    if (runner._harness) {
-      runner._harness.app.pages.forEach(function(page) {
+    runner.harnesses.forEach(function(harness) {
+      harness.app._pages.forEach(function(page) {
         page.destroy();
       });
-    }
-    runner._harness = null;
+    });
+    runner.harnesses = [];
 
     jsdom.window.close();
     runner.window = null;

--- a/test-utils/domTestRunner.js
+++ b/test-utils/domTestRunner.js
@@ -36,6 +36,7 @@ DomTestRunner.prototype.createHarness = function() {
   if (arguments.length > 0) {
     harness.setup.apply(harness, arguments);
   }
+  runner._harness = harness;
   return harness;
 };
 
@@ -61,6 +62,13 @@ function mochaHooksForNode(runner, options) {
   });
 
   global.afterEach(function() {
+    // Destroy the most recent page on the harness, so that if a test cleans up its model itself,
+    // bindings won't throw errors due to `document` not being present.
+    if (runner._harness && runner._harness.app.page) {
+      runner._harness.app.page.destroy();
+    }
+    runner._harness = null;
+
     jsdom.window.close();
     runner.window = null;
     runner.document = null;

--- a/test-utils/domTestRunner.js
+++ b/test-utils/domTestRunner.js
@@ -62,10 +62,12 @@ function mochaHooksForNode(runner, options) {
   });
 
   global.afterEach(function() {
-    // Destroy the most recent page on the harness, so that if a test cleans up its model itself,
+    // Destroy the pages created by the harness, so that if a test cleans up its model itself,
     // bindings won't throw errors due to `document` not being present.
-    if (runner._harness && runner._harness.app.page) {
-      runner._harness.app.page.destroy();
+    if (runner._harness) {
+      runner._harness.app.pages.forEach(function(page) {
+        page.destroy();
+      });
     }
     runner._harness = null;
 


### PR DESCRIPTION
1. Fix a `Component#destroy` error when no components on the page use bindings.

    - If no components on the current page use bindings, then `Component#destroy` would fail due to `this.page._eventModel.object` not existing, since `_eventModel.object` [starts off null](https://github.com/derbyjs/derby/blob/4e6bbb52da510dddc0767f1c8bf5ee9939e7b201/lib/eventmodel.js#L98) and [is lazily initialized when a binding needs it](https://github.com/derbyjs/derby/blob/master/lib/eventmodel.js#L160).
    - This fix guards against that case. There's no need to clean up `.object` if it was never initialized.

2. For test-utils, ComponentHarness now tracks the pages it creates, and the DomTestRunner then uses that to destroy the created pages in an `afterEach`.
    - This prevents silent post-test errors like "document is not defined" from cropping up when a test manually closes its model - those errors were due to bindings triggering off the model.