### PR TITLE
Add context to error on Unexpected token error

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -60,7 +60,7 @@ App.prototype._init = function() {
 };
 App.prototype._finishInit = function() {
   var script = this._getScript();
-  var data = JSON.parse(script.nextSibling.innerHTML);
+  var data = parseState(script.nextSibling.innerHTML);
   this.model.createConnection(data);
   this.emit('model', this.model);
   util.isProduction = data.nodeEnv === 'production';
@@ -358,3 +358,21 @@ App.prototype._handleMessage = function(action, message) {
     });
   }
 };
+
+function parseState(innerHtml) {
+  try {
+    return JSON.parse(innerHtml);
+  } catch (error) {
+    var message = error.message || '';
+    var match = message.match(/Unexpected token (.) in JSON at position (\d+)/);
+    if (match) {
+      var p = parseInt(match[2], 10);
+      var stringContext = innerHtml.substring(
+        Math.min(0, p - 30),
+        Math.max(p + 30, innerHtml.length - 1),
+      );
+      throw new Error('Parse failure: ' + error.message + ' context: \'' + stringContext + '\'');
+    }
+    throw error;
+  }
+}

--- a/lib/App.js
+++ b/lib/App.js
@@ -60,7 +60,7 @@ App.prototype._init = function() {
 };
 App.prototype._finishInit = function() {
   var script = this._getScript();
-  var data = parseState(script.nextSibling.innerHTML);
+  var data = App._parseInitialData(script.nextSibling.innerHTML);
   this.model.createConnection(data);
   this.emit('model', this.model);
   util.isProduction = data.nodeEnv === 'production';
@@ -359,17 +359,17 @@ App.prototype._handleMessage = function(action, message) {
   }
 };
 
-function parseState(innerHtml) {
+App._parseInitialData = function _parseInitialData(jsonString) {
   try {
-    return JSON.parse(innerHtml);
+    return JSON.parse(jsonString);
   } catch (error) {
     var message = error.message || '';
     var match = message.match(/Unexpected token (.) in JSON at position (\d+)/);
     if (match) {
       var p = parseInt(match[2], 10);
-      var stringContext = innerHtml.substring(
+      var stringContext = jsonString.substring(
         Math.min(0, p - 30),
-        Math.max(p + 30, innerHtml.length - 1),
+        Math.max(p + 30, jsonString.length - 1),
       );
       throw new Error('Parse failure: ' + error.message + ' context: \'' + stringContext + '\'');
     }

--- a/lib/App.js
+++ b/lib/App.js
@@ -369,10 +369,10 @@ App._parseInitialData = function _parseInitialData(jsonString) {
       var p = parseInt(match[2], 10);
       var stringContext = jsonString.substring(
         Math.min(0, p - 30),
-        Math.max(p + 30, jsonString.length - 1),
+        Math.max(p + 30, jsonString.length - 1)
       );
       throw new Error('Parse failure: ' + error.message + ' context: \'' + stringContext + '\'');
     }
     throw error;
   }
-}
+};

--- a/test/all/App.mocha.js
+++ b/test/all/App.mocha.js
@@ -1,23 +1,23 @@
-const expect = require('chai').expect;
-const App = require('../../lib/App');
+var expect = require('chai').expect;
+var App = require('../../lib/App');
 
 describe('App._parseInitialData', () => {
   it('parses simple json', () => {
-    const actual = App._parseInitialData('{"foo": "bar"}');
+    var actual = App._parseInitialData('{"foo": "bar"}');
     expect(actual).to.deep.equal({ foo: 'bar' });
   });
 
   it('parses escaped json', () => {
-    const actual = App._parseInitialData('{"foo": "<\\u0021bar><\\/bar>"}');
+    var actual = App._parseInitialData('{"foo": "<\\u0021bar><\\/bar>"}');
     expect(actual).to.deep.equal({ foo: '<!bar></bar>' });
   });
 
   it('thorws error with context for unexpected tokens', () => {
     try {
-      const actual = App._parseInitialData('{"foo": b}');
+      var actual = App._parseInitialData('{"foo": b}');
     } catch (error) {
       expect(error.message).to.equal(
-        'Parse failure: Unexpected token b in JSON at position 8 context: \'{"foo": b}\'',
+        'Parse failure: Unexpected token b in JSON at position 8 context: \'{"foo": b}\''
       );
     }
   });

--- a/test/all/App.mocha.js
+++ b/test/all/App.mocha.js
@@ -13,12 +13,11 @@ describe('App._parseInitialData', () => {
   });
 
   it('thorws error with context for unexpected tokens', () => {
-    try {
-      var actual = App._parseInitialData('{"foo": b}');
-    } catch (error) {
-      expect(error.message).to.equal(
-        'Parse failure: Unexpected token b in JSON at position 8 context: \'{"foo": b}\''
-      );
-    }
+    var fn = function() {
+      return App._parseInitialData('{"foo": b}');
+    };
+    expect(fn).to.throw(
+      'Parse failure: Unexpected token b in JSON at position 8 context: \'{"foo": b}\''
+    );
   });
 });

--- a/test/all/App.mocha.js
+++ b/test/all/App.mocha.js
@@ -13,10 +13,7 @@ describe('App._parseInitialData', () => {
   });
 
   it('thorws error with context for unexpected tokens', () => {
-    var fn = function() {
-      return App._parseInitialData('{"foo": b}');
-    };
-    expect(fn).to.throw(
+    expect(() => App._parseInitialData('{"foo": b}')).to.throw(
       'Parse failure: Unexpected token b in JSON at position 8 context: \'{"foo": b}\''
     );
   });

--- a/test/all/App.mocha.js
+++ b/test/all/App.mocha.js
@@ -1,0 +1,24 @@
+const expect = require('chai').expect;
+const App = require('../../lib/App');
+
+describe('App._parseInitialData', () => {
+  it('parses simple json', () => {
+    const actual = App._parseInitialData('{"foo": "bar"}');
+    expect(actual).to.deep.equal({ foo: 'bar' });
+  });
+
+  it('parses escaped json', () => {
+    const actual = App._parseInitialData('{"foo": "<\\u0021bar><\\/bar>"}');
+    expect(actual).to.deep.equal({ foo: '<!bar></bar>' });
+  });
+
+  it('thorws error with context for unexpected tokens', () => {
+    try {
+      const actual = App._parseInitialData('{"foo": b}');
+    } catch (error) {
+      expect(error.message).to.equal(
+        'Parse failure: Unexpected token b in JSON at position 8 context: \'{"foo": b}\'',
+      );
+    }
+  });
+});


### PR DESCRIPTION
Parse errors from JSON.parse() to add useful context on unexpected token errors.

On `_finishInit()` calls, if the `innerHTML` of the app state element is invalid JSON, then an unhelpful error like `Uncaught SyntaxError: Unexpected token h in JSON at position 13540` is all the context you have. This parsing is done to rehydrate the app state as written by https://github.com/derbyjs/derby/blob/master/lib/PageForServer.js#L83-L94 which does some escaping of the string to prevent the script tag from being prematurely closed