### PR TITLE
Stop testing EOL node versions 8 and 10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ jobs:
     strategy:
       matrix:
         node:
-          - 8
-          - 10
           - 12
           - 14
     timeout-minutes: 10


### PR DESCRIPTION
Remove node version 8 and 10 form test matrix.