### PR TITLE
Safe `requestAnimationFrame` and `nextTick` methods

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -149,6 +149,27 @@ Component.prototype.throttle = function(callback, delayArg) {
   throw new Error('Second argument must be a delay function or number');
 };
 
+function _safeWrap(component, callback) {
+  return function() {
+    if (component.isDestroyed) return;
+    callback.call(component);
+  }
+}
+
+// Checks that component is not destroyed before calling callback function
+// which avoids possible bugs and memory leaks.
+Component.prototype.requestAnimationFrame= function(callback) {
+  var safeCallback = _safeWrap(this, callback);
+  window.requestAnimationFrame(safeCallback);
+}
+
+// Checks that component is not destroyed before calling callback function
+// which avoids possible bugs and memory leaks.
+Component.prototype.nextTick= function(callback) {
+  var safeCallback = _safeWrap(this, callback);
+  process.nextTick(safeCallback);
+}
+
 // Suppresses calls until the function is no longer called for that many
 // milliseconds. This should be used for delaying updates triggered by user
 // input, such as window resizing, or typing text that has a live preview or

--- a/lib/components.js
+++ b/lib/components.js
@@ -158,17 +158,17 @@ function _safeWrap(component, callback) {
 
 // Checks that component is not destroyed before calling callback function
 // which avoids possible bugs and memory leaks.
-Component.prototype.requestAnimationFrame= function(callback) {
+Component.prototype.requestAnimationFrame = function(callback) {
   var safeCallback = _safeWrap(this, callback);
   window.requestAnimationFrame(safeCallback);
-}
+};
 
 // Checks that component is not destroyed before calling callback function
 // which avoids possible bugs and memory leaks.
-Component.prototype.nextTick= function(callback) {
+Component.prototype.nextTick = function(callback) {
   var safeCallback = _safeWrap(this, callback);
   process.nextTick(safeCallback);
-}
+};
 
 // Suppresses calls until the function is no longer called for that many
 // milliseconds. This should be used for delaying updates triggered by user

--- a/lib/components.js
+++ b/lib/components.js
@@ -153,7 +153,7 @@ function _safeWrap(component, callback) {
   return function() {
     if (component.isDestroyed) return;
     callback.call(component);
-  }
+  };
 }
 
 // Checks that component is not destroyed before calling callback function


### PR DESCRIPTION
- Add component wrapper methods for `window.requestAnimationFrame` and `process.nextTick`

In some situations components can be disposed of before callbacks are triggered when invoked when provided to `window.requestAnimationFrame` and `process.nextTick` This adds methods on the components to safely ignore callbacks if component has already been destroyed.
