### PR TITLE
Switch tracks dependency to new scoped NPM package `@derbyjs/tracks`

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -8,7 +8,7 @@
 
 var path = require('path');
 var EventEmitter = require('events').EventEmitter;
-var tracks = require('tracks');
+var tracks = require('@derbyjs/tracks');
 var util = require('racer/lib/util');
 var derbyTemplates = require('derby-templates');
 var templates = derbyTemplates.templates;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test-browser": "node test/server.js"
   },
   "dependencies": {
+    "@derbyjs/tracks": "^1.0.0",
     "chokidar": "^3.5.3",
     "derby-parsing": "^0.8.0",
     "derby-templates": "^0.8.1",
@@ -22,8 +23,7 @@
     "qs": "^6.11.0",
     "racer": "^1.0.3",
     "resolve": "^1.22.1",
-    "through": "^2.3.8",
-    "tracks": "^0.5.8"
+    "through": "^2.3.8"
   },
   "devDependencies": {
     "async": "^3.2.4",


### PR DESCRIPTION
To make package maintenance easier, we decided to switch to scoped NPM packages. First one to move is `tracks` to `@derbyjs/tracks`, which shouldn't be directly used.

As part of this, Derby will also pick up a tracks fix to preserve URL hashes across page transitions:
https://github.com/derbyjs/tracks/pull/31