### PR TITLE
Dynamic app views

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -14,7 +14,6 @@ var derbyTemplates = require('derby-templates');
 var templates = derbyTemplates.templates;
 var components = require('./components');
 var PageBase = require('./Page');
-var serializedViews = require('./_views');
 
 module.exports = App;
 
@@ -65,6 +64,25 @@ App.prototype._init = function() {
   this._waitForAttach = true;
   this._cancelAttach = false;
   this.model = new this.derby.Model();
+  const appname = this.name;
+
+  // import(viewImport).then(serializedViews => {
+  //   console.log(serializedViews);
+  //   serializedViews(derbyTemplates, this.views);
+  //   // Must init async so that app.on('model') listeners can be added.
+  //   // Must also wait for content ready so that bundle is fully downloaded.
+  //   this._contentReady();
+  // })
+
+  // require.ensure([`derby/lib/${appname}__views`]).then(require => {
+  //   const serializedViews = requrie(`derby/lib/${appname}__views`)
+  //   serializedViews(derbyTemplates, this.views);
+  //   // Must init async so that app.on('model') listeners can be added.
+  //   // Must also wait for content ready so that bundle is fully downloaded.
+  //   this._contentReady();
+  // });
+
+  const serializedViews = require(`derby/lib/${appname}__views`);
   serializedViews(derbyTemplates, this.views);
   // Must init async so that app.on('model') listeners can be added.
   // Must also wait for content ready so that bundle is fully downloaded.

--- a/lib/App.js
+++ b/lib/App.js
@@ -72,7 +72,7 @@ App.prototype._init = function() {
 };
 
 App.prototype._views = function () {
-  return require('derby/lib/_views');
+  return require('./_views');
 }
 
 App.prototype._finishInit = function() {

--- a/lib/App.js
+++ b/lib/App.js
@@ -64,30 +64,16 @@ App.prototype._init = function() {
   this._waitForAttach = true;
   this._cancelAttach = false;
   this.model = new this.derby.Model();
-  const appname = this.name;
-
-  // import(viewImport).then(serializedViews => {
-  //   console.log(serializedViews);
-  //   serializedViews(derbyTemplates, this.views);
-  //   // Must init async so that app.on('model') listeners can be added.
-  //   // Must also wait for content ready so that bundle is fully downloaded.
-  //   this._contentReady();
-  // })
-
-  // require.ensure([`derby/lib/${appname}__views`]).then(require => {
-  //   const serializedViews = requrie(`derby/lib/${appname}__views`)
-  //   serializedViews(derbyTemplates, this.views);
-  //   // Must init async so that app.on('model') listeners can be added.
-  //   // Must also wait for content ready so that bundle is fully downloaded.
-  //   this._contentReady();
-  // });
-
-  const serializedViews = require(`derby/lib/${appname}__views`);
+  const serializedViews = this._views();
   serializedViews(derbyTemplates, this.views);
   // Must init async so that app.on('model') listeners can be added.
   // Must also wait for content ready so that bundle is fully downloaded.
   this._contentReady();
 };
+
+App.prototype._views = function () {
+  return require('derby/lib/_views');
+}
 
 App.prototype._finishInit = function() {
   var script = this._getAppStateScript();

--- a/lib/App.js
+++ b/lib/App.js
@@ -64,7 +64,7 @@ App.prototype._init = function() {
   this._waitForAttach = true;
   this._cancelAttach = false;
   this.model = new this.derby.Model();
-  const serializedViews = this._views();
+  var serializedViews = this._views();
   serializedViews(derbyTemplates, this.views);
   // Must init async so that app.on('model') listeners can be added.
   // Must also wait for content ready so that bundle is fully downloaded.


### PR DESCRIPTION
Move require of views to `init()` function and call `_views()` to get module, allowing override of method via other plugins (notably `derby-webpack`)