### PR TITLE
In hot module reload, destroy previous app's page

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -19,15 +19,6 @@ module.exports = App;
 
 globalThis.APPS = globalThis.APPS || new Map();
 
-App.register = function register(name) {
-  if (!globalThis.APPS.has(name)) {
-    globalThis.APPS.set(name, {
-      attached: false,
-      initialState: null,
-    });
-  }
-}
-
 function App(derby, name, filename, options) {
   EventEmitter.call(this);
   this.derby = derby;
@@ -43,7 +34,6 @@ function App(derby, name, filename, options) {
   this.page = null;
   this._pendingComponentMap = {};
   this._init(options);
-  App.register(name);
 }
 
 function createAppPage(derby) {
@@ -76,20 +66,36 @@ App.prototype._views = function () {
 }
 
 App.prototype._finishInit = function() {
-  var script = this._getAppStateScript();
-  var data = App._parseInitialData(script.textContent);
+  var data = this._getAppData();
+  util.isProduction = data.nodeEnv === 'production';
+
+  var previousAppInfo;
+  if (!util.isProduction) {
+    previousAppInfo = globalThis.APPS.get(this.name);
+    if (previousAppInfo) {
+      previousAppInfo.app._destroyCurrentPage();
+    }
+    globalThis.APPS.set(this.name, {
+      app: this,
+      initialState: data,
+    });
+  }
+
   this.model.createConnection(data);
   this.emit('model', this.model);
-  util.isProduction = data.nodeEnv === 'production';
+
   if (!util.isProduction) this._autoRefresh();
+
   this.model.unbundle(data);
+
   var page = this.createPage();
   page.params = this.model.get('$render.params');
   this.emit('ready', page);
+
   this._waitForAttach = false;
   // Instead of attaching, do a route and render if a link was clicked before
-  // the page finished attaching
-  if (this._cancelAttach || this._isAttached()) {
+  // the page finished attaching, or if this is a new app from hot reload.
+  if (this._cancelAttach || previousAppInfo) {
     this.history.refresh();
     return;
   }
@@ -109,24 +115,13 @@ App.prototype._finishInit = function() {
   this.emit('load', page);
 };
 
-App.prototype._isAttached = function isInitialized() {
-  var attached = globalThis.APPS.get(this.name).attached;
-  return attached;
-}
-
-App.prototype._persistInitialState = function persistInitialState(state) {
-  if (this._isAttached()) {
-    return;
+App.prototype._getAppData = function () {
+  var script = this._getAppStateScript();
+  if (script) {
+    return App._parseInitialData(script.textContent);
+  } else {
+    return globalThis.APPS.get(this.name).initialState;
   }
-  globalThis.APPS.set(this.name, {
-    attached: true,
-    initialState: state,
-  });
-}
-
-App.prototype._initialState = function initialState() {
-  var initialState = globalThis.APPS.get(this.name).initialState;
-  return initialState;
 }
 
 // Modified from: https://github.com/addyosmani/jquery.parts/blob/master/jquery.documentReady.js
@@ -325,13 +320,17 @@ App.prototype.component = function(name, constructor, isDependency) {
 };
 
 App.prototype.createPage = function() {
+  this._destroyCurrentPage();
+  var page = new this.Page(this, this.model);
+  this.page = page;
+  return page;
+};
+
+App.prototype._destroyCurrentPage = function() {
   if (this.page) {
     this.emit('destroyPage', this.page);
     this.page.destroy();
   }
-  var page = new this.Page(this, this.model);
-  this.page = page;
-  return page;
 };
 
 App.prototype.onRoute = function(callback, page, next, done) {

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "async": "^3.2.4",
     "browserify": "^17.0.0",
     "chai": "^4.3.6",
+    "eslint": "^8.37.0",
     "express": "^4.18.1",
     "jsdom": "^20.0.1",
-    "jshint": "^2.13.5",
     "mocha": "^10.0.0"
   },
   "optionalDependencies": {},


### PR DESCRIPTION
Hot module reload causes a new app instance to be created. To prevent multiple instances of the same app from manipulating the same data, destroy the previous instance's active page before initializing components on the new instance.