### PR TITLE
Use env vars to set version strings

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -25,8 +25,9 @@ function App(derby, name, filename, options) {
   this.derby = derby;
   this.name = name;
   this.filename = filename;
-  this.scriptHash = '{{DERBY_SCRIPT_HASH}}';
-  this.bundledAt = '{{DERBY_BUNDLED_AT}}';
+  this.scriptHash = process.env.DERBY_SCRIPT_HASH || '{{DERBY_SCRIPT_HASH}}';
+  this.bundledAt = process.env.DERBY_BUNDLED_AT || '{{DERBY_BUNDLED_AT}}';
+  this.buildVersion = process.env.DERBY_BUILD_VERSION;
   this.Page = createAppPage(derby);
   this.proto = this.Page.prototype;
   this.views = new templates.Views();


### PR DESCRIPTION
Use environment variables to set `scriptHash`, `bundledAt`, and add new attribute `buildVersion`