### PR TITLE
Remove vargs check as arg order switched to match client Page

### DIFF
--- a/src/PageForServer.ts
+++ b/src/PageForServer.ts
@@ -18,10 +18,6 @@ export class PageForServer<T = object> extends PageBase<T> {
   }
 
   render(ns?: string, status?: number) {
-    if (typeof status !== 'number') {
-      ns = status;
-      status = null;
-    }
     this.app.emit('render', this);
 
     if (status) this.res.statusCode = status;


### PR DESCRIPTION
Unifying the `Page.render` and `PageForServer.render` args resulted in changing arg order so `status` is last optional arg. 

This removes the now incorrect var ags handling for `PageForServer.render` 