### PR TITLE
[derby@2] Fix bug registering component with static `view.is` prop but no `view.file` prop

### DIFF
--- a/lib/App.js
+++ b/lib/App.js
@@ -299,9 +299,13 @@ App.prototype.component = function(name, constructor, isDependency) {
     this.addViews(viewSource, viewName);
     view = this.views.find(viewName);
 
-  } else if (name) {
+  } else if (viewName) {
+    // Look for a previously registered view matching the component name.
     view = this.views.find(viewName);
-
+    // If no match, register a new empty view, for backwards compatibility.
+    if (!view) {
+      view = this.views.register(viewName, '');
+    }
   } else {
     view = this.views.register(viewName, '');
   }

--- a/test/dom/components.mocha.js
+++ b/test/dom/components.mocha.js
@@ -1,0 +1,58 @@
+var expect = require('chai').expect;
+var pathLib = require('node:path');
+var domTestRunner = require('../../test-utils/domTestRunner');
+
+describe('components', function() {
+  var runner = domTestRunner.install();
+
+  describe('app.component registration', function() {
+    describe('passing just component class', function() {
+      describe('with static view prop', function() {
+        it('external view file', function() {
+          var harness = runner.createHarness();
+
+          function SimpleBox() {}
+          SimpleBox.view = {
+            is: 'simple-box',
+            // Static `view.file` property, defining path of view file
+            file: pathLib.resolve(__dirname, '../fixtures/simple-box')
+          };
+          harness.app.component(SimpleBox);
+
+          harness.setup('<view is="simple-box"/>');
+          expect(harness.renderHtml().html).to.equal('<div class="simple-box"></div>');
+        });
+
+        it('inlined view.source', function() {
+          var harness = runner.createHarness();
+
+          function SimpleBox() {}
+          SimpleBox.view = {
+            is: 'simple-box',
+            source: '<index:><div>Inlined source</div>'
+          };
+          harness.app.component(SimpleBox);
+
+          harness.setup('<view is="simple-box"/>');
+          expect(harness.renderHtml().html).to.equal('<div>Inlined source</div>');
+        });
+
+        it('inferred view file from view name', function() {
+          var harness = runner.createHarness();
+
+          // Pre-load view with same name as the component's static `view.is`
+          harness.app.loadViews(pathLib.resolve(__dirname, '../fixtures/simple-box'), 'simple-box');
+
+          function SimpleBox() {}
+          SimpleBox.view = {
+            is: 'simple-box'
+          };
+          harness.app.component(SimpleBox);
+
+          harness.setup('<view is="simple-box"/>');
+          expect(harness.renderHtml().html).to.equal('<div class="simple-box"></div>');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Same as https://github.com/derbyjs/derby/pull/627, but based on and merging into pre-TypeScript `v2` branch, to fix it for code using Derby v2.