### PR TITLE
Fix error in server app.renderStatic

### DIFF
--- a/src/PageForServer.ts
+++ b/src/PageForServer.ts
@@ -84,7 +84,8 @@ function stringifyBundle(bundle) {
 
 // TODO: Cleanup; copied from tracks
 function pageParams(req) {
-  const params = Object.create(null, {
+  const params = Object.create(null);
+  Object.assign(params, {
     url: req.url,
     body: req.body,
     query: req.query,


### PR DESCRIPTION
Broke it in https://github.com/derbyjs/derby/pull/630 - I misunderstood the second param to `Object.create`.