### PR TITLE
Add package.json exports for derby/dist/{components,parsing,templates,test-utils} for compat with TS classic moduleResolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,14 +14,19 @@
   "exports": {
     ".": "./dist/index.js",
     "./components": "./dist/components.js",
+    "./dist/components": "./dist/components.js",
     "./parsing": "./dist/parsing/index.js",
+    "./dist/parsing": "./dist/parsing/index.js",
     "./templates": "./dist/templates/index.js",
+    "./dist/templates": "./dist/templates/index.js",
     "./App": "./dist/App.js",
     "./AppForServer": "./dist/AppForServer.js",
     "./server": "./dist/server.js",
     "./Page": "./dist/Page.js",
     "./test-utils": "./dist/test-utils/index.js",
     "./test-utils/*": "./dist/test-utils/*.js",
+    "./dist/test-utils": "./dist/test-utils/index.js",
+    "./dist/test-utils/*": "./dist/test-utils/*.js",
     "./file-utils": "./dist/files.js"
   },
   "files": [


### PR DESCRIPTION
Some modules in derby, like test-utils, are not accessible from the root package export. TypeScript with the default classic moduleResolution (pre `"node16"`) doesn't use the package.json `exports` field, so the only way to use such modules is by using the `dist` paths, e.g. `'derby/dist/test-utils'` instead of the exports-mapped `'derby/test-utils'`.

This adds package.json `exports` `dist/*` paths for a selection of such modules that are useful in consumers.