### PR TITLE
Make RenderOptions optional

### DIFF
--- a/src/test-utils/ComponentHarness.ts
+++ b/src/test-utils/ComponentHarness.ts
@@ -16,8 +16,18 @@ export interface RenderOptions {
 
 export class PageForHarness extends PageForClient {
   component?: Component;
-  fragment?: any;
-  html?: any;
+  fragment?: DocumentFragment;
+  html?: string;
+}
+
+interface PageRenderedHtml extends PageForHarness {
+  html: string;
+  fragment: undefined;
+}
+
+interface PageRenderedFragment extends PageForHarness {
+  html: undefined;
+  fragment: DocumentFragment;
 }
 
 const derby = new DerbyForClient();
@@ -158,10 +168,10 @@ export class ComponentHarness extends EventEmitter {
    * @returns { Page & {html: string} } - a `Page` that has a `html` property with the rendered HTML
    *   string
    */
-  renderHtml(options?: RenderOptions) {
+  renderHtml(options?: RenderOptions): PageRenderedHtml {
     return this._get(function(page) {
       page.html = page.get('$harness');
-    }, options);
+    }, options) as PageRenderedHtml;
   }
   
   /**
@@ -171,10 +181,10 @@ export class ComponentHarness extends EventEmitter {
    * @returns { Page & {fragment: DocumentFragment} } a `Page` that has a `fragment` property with the
    *   rendered `DocumentFragment`
    */
-  renderDom(options?: RenderOptions) {
+  renderDom(options?: RenderOptions): PageRenderedFragment {
     return this._get(function(page) {
       page.fragment = page.getFragment('$harness');
-    }, options);
+    }, options) as PageRenderedFragment;
   }
   
   attachTo(parentNode, node) {

--- a/src/test-utils/ComponentHarness.ts
+++ b/src/test-utils/ComponentHarness.ts
@@ -158,7 +158,7 @@ export class ComponentHarness extends EventEmitter {
    * @returns { Page & {html: string} } - a `Page` that has a `html` property with the rendered HTML
    *   string
    */
-  renderHtml(options) {
+  renderHtml(options?: RenderOptions) {
     return this._get(function(page) {
       page.html = page.get('$harness');
     }, options);
@@ -171,7 +171,7 @@ export class ComponentHarness extends EventEmitter {
    * @returns { Page & {fragment: DocumentFragment} } a `Page` that has a `fragment` property with the
    *   rendered `DocumentFragment`
    */
-  renderDom(options) {
+  renderDom(options?: RenderOptions) {
     return this._get(function(page) {
       page.fragment = page.getFragment('$harness');
     }, options);
@@ -189,7 +189,7 @@ export class ComponentHarness extends EventEmitter {
    * @param {(page: PageForHarness) => void} render
    * @param {RenderOptions} [options]
    */
-  _get(renderFn: (page: PageForHarness) => void, options?): PageForHarness {
+  _get(renderFn: (page: PageForHarness) => void, options?: RenderOptions): PageForHarness {
     options = options || {};
     const url = options.url || '';
   


### PR DESCRIPTION
Fixes `ComponentHarness` methods `renderHtml` and `renderDom` not having optional `options` argument

Additionally `renderHtml` and `renderDom` both returned `PageForHarness` which left relevant `html` or `fragment` attributes as nullable. This adds return types for each method with appropriate non-null attribure (e.g. `html: string` for `renderHtml`)