### PR TITLE
Fix derby/server cluster imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "./App": "./dist/App.js",
     "./AppForServer": "./dist/AppForServer.js",
     "./server": "./dist/server.js",
+    "./dist/server": "./dist/server.js",
     "./Page": "./dist/Page.js",
     "./test-utils": "./dist/test-utils/index.js",
     "./test-utils/*": "./dist/test-utils/*.js",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,10 +1,12 @@
-import cluster from 'cluster';
+// import as namespace to avoid transform as cluster.default 
+import * as cluster from 'node:cluster';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
 export function run(createServer: () => void) {
   // In production
   if (isProduction) return createServer();
+  // @ts-expect-error imported without default; need type update?
   if (cluster.isPrimary) {
     console.log('Primary PID ', process.pid);
     startWorker();
@@ -14,6 +16,7 @@ export function run(createServer: () => void) {
 }
 
 function startWorker() {
+  // @ts-expect-error imported without default; need type update?
   const worker = cluster.fork();
   
   worker.once('disconnect', function () {


### PR DESCRIPTION
Downstream code failing when using `derby/server` as `cluster` imported in trasformed with `default` import like this:

```
// there is no cluster.default
 if (cluster.default.isPrimary) {
    console.log('Primary PID ', process.pid);
    startWorker();
  }
```

and erors with `default is undefined`

Additionally added forward compatible mapping for pre node16 module resolutions for server 