### PR TITLE
Add source as optional param to stub

### DIFF
--- a/src/test-utils/ComponentHarness.ts
+++ b/src/test-utils/ComponentHarness.ts
@@ -122,7 +122,7 @@ export class ComponentHarness extends EventEmitter {
    *     {is: 'dialog:buttons', source: '<button>OK</button>'}
    *   );
    */
-  stub(...args: Array<string | { is: string }>) {
+  stub(...args: Array<string | { is: string, source?: string }>) {
     for (let i = 0; i < args.length; i++) {
       // eslint-disable-next-line prefer-rest-params
       const arg = arguments[i];


### PR DESCRIPTION
Updating the input type of `stub` function to allow `source` property to be passed in.   This change allows other TS files calling `harness.stub` to pass in a view source to `harness.app.views.register`.  If `source` isn't passed in, `stub` will continue to register with a view of `''`. 

https://github.com/derbyjs/derby/blob/37e41363bf3733921529f6bbb4888f859c652734/src/test-utils/ComponentHarness.ts#L132