### PR TITLE
Fix doc site api-doc generation

### DIFF
--- a/.github/workflows/docs-gh-pages.yml
+++ b/.github/workflows/docs-gh-pages.yml
@@ -37,8 +37,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18
-      - name: Build with Typedoc
-        run: npm i && npm run docs
       - name: Setup Ruby
         uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
         with:
@@ -49,9 +47,11 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v4
-      - name: Build with Jekyll
-        # Outputs to the './_site' directory by default
-        run: cd $DOCS_DIR && bundle install && bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+      - name: Build with Typedoc
+        run: npm i && npm run docs
+      - name: Build documentaiton site
+        working-directory: ${{ env.DOCS_DIR }}
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
       - name: Upload artifact

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 node_modules
 .vscode
 dist/
-docs/api/

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -40,8 +40,7 @@ markdown: kramdown
 theme: just-the-docs
 color_scheme: derby-light # just-the-docs theme customization
 permalink: /:path/:name
-keep_files:
-  - api/
+keep_files: [api]
 
 # just-the-docs customization
 callouts:


### PR DESCRIPTION
Jekyll was clobbering API doc output form Typedoc. Fixed w correct `keep_files` in jekyll config. Additionally, streamlined action steps - used `working-directory` and removed redundant `bundle install` handled by ruby setup step