### PR TITLE
Add overloads to support passing single string arg to renderStatic

### DIFF
--- a/src/PageForServer.ts
+++ b/src/PageForServer.ts
@@ -55,14 +55,16 @@ export class PageForServer extends Page {
     });
   }
 
-  renderStatic(status?: number, ns?: string) {
+  renderStatic(ns: string): void;
+  renderStatic(status: number, ns?: string): void;
+  renderStatic(status?: number | string, ns?: string) {
     if (typeof status !== 'number') {
       ns = status;
       status = null;
     }
     this.app.emit('renderStatic', this);
 
-    if (status) this.res.statusCode = status;
+    if (typeof status === 'number') this.res.statusCode = status;
     this.params = pageParams(this.req);
     this._setRenderParams(ns);
     const pageHtml = this.get('Page', ns);


### PR DESCRIPTION
The renderStatic method from PageForServer supports passing 1-2 arguments. This proposes adding some overloads to reflect the case where a single string argument is passed.

Due to the type ambiguity introduced for the first argument, also adds an additional `typeof` check. Depending on preference, an `else` clause could also be added to the first conditional instead.

Examples:

```
// string only
page.renderStatic('signup');

// number, string
page.renderStatic(401, 'login');
```